### PR TITLE
Add flexible device selection

### DIFF
--- a/wan/image2video.py
+++ b/wan/image2video.py
@@ -71,7 +71,12 @@ class WanI2V:
                 Convert DiT model parameters dtype to 'config.param_dtype'.
                 Only works without FSDP.
         """
-        self.device = torch.device(f"cuda:{device_id}")
+        if torch.cuda.is_available():
+            self.device = torch.device(f"cuda:{device_id}")
+        elif torch.backends.mps.is_available():
+            self.device = torch.device("mps")
+        else:
+            self.device = torch.device("cpu")
         self.config = config
         self.rank = rank
         self.t5_cpu = t5_cpu
@@ -88,7 +93,7 @@ class WanI2V:
         self.text_encoder = T5EncoderModel(
             text_len=config.text_len,
             dtype=config.t5_dtype,
-            device=torch.device('cpu'),
+            device=self.device,
             checkpoint_path=os.path.join(checkpoint_dir, config.t5_checkpoint),
             tokenizer_path=os.path.join(checkpoint_dir, config.t5_tokenizer),
             shard_fn=shard_fn if t5_fsdp else None,

--- a/wan/modules/t5.py
+++ b/wan/modules/t5.py
@@ -475,11 +475,18 @@ class T5EncoderModel:
         self,
         text_len,
         dtype=torch.bfloat16,
-        device=torch.cuda.current_device(),
+        device=None,
         checkpoint_path=None,
         tokenizer_path=None,
         shard_fn=None,
     ):
+        if device is None:
+            if torch.cuda.is_available():
+                device = torch.device(f"cuda:{torch.cuda.current_device()}")
+            elif torch.backends.mps.is_available():
+                device = torch.device("mps")
+            else:
+                device = torch.device("cpu")
         self.text_len = text_len
         self.dtype = dtype
         self.device = device

--- a/wan/text2video.py
+++ b/wan/text2video.py
@@ -69,7 +69,12 @@ class WanT2V:
                 Convert DiT model parameters dtype to 'config.param_dtype'.
                 Only works without FSDP.
         """
-        self.device = torch.device(f"cuda:{device_id}")
+        if torch.cuda.is_available():
+            self.device = torch.device(f"cuda:{device_id}")
+        elif torch.backends.mps.is_available():
+            self.device = torch.device("mps")
+        else:
+            self.device = torch.device("cpu")
         self.config = config
         self.rank = rank
         self.t5_cpu = t5_cpu
@@ -86,7 +91,7 @@ class WanT2V:
         self.text_encoder = T5EncoderModel(
             text_len=config.text_len,
             dtype=config.t5_dtype,
-            device=torch.device('cpu'),
+            device=self.device,
             checkpoint_path=os.path.join(checkpoint_dir, config.t5_checkpoint),
             tokenizer_path=os.path.join(checkpoint_dir, config.t5_tokenizer),
             shard_fn=shard_fn if t5_fsdp else None)

--- a/wan/textimage2video.py
+++ b/wan/textimage2video.py
@@ -72,7 +72,12 @@ class WanTI2V:
                 Convert DiT model parameters dtype to 'config.param_dtype'.
                 Only works without FSDP.
         """
-        self.device = torch.device(f"cuda:{device_id}")
+        if torch.cuda.is_available():
+            self.device = torch.device(f"cuda:{device_id}")
+        elif torch.backends.mps.is_available():
+            self.device = torch.device("mps")
+        else:
+            self.device = torch.device("cpu")
         self.config = config
         self.rank = rank
         self.t5_cpu = t5_cpu
@@ -88,7 +93,7 @@ class WanTI2V:
         self.text_encoder = T5EncoderModel(
             text_len=config.text_len,
             dtype=config.t5_dtype,
-            device=torch.device('cpu'),
+            device=self.device,
             checkpoint_path=os.path.join(checkpoint_dir, config.t5_checkpoint),
             tokenizer_path=os.path.join(checkpoint_dir, config.t5_tokenizer),
             shard_fn=shard_fn if t5_fsdp else None)


### PR DESCRIPTION
## Summary
- Add cross-platform device selection falling back to MPS or CPU
- Pass chosen device into T5 encoder initialization
- Make T5 encoder default device dynamic

## Testing
- `python -m py_compile wan/text2video.py wan/image2video.py wan/textimage2video.py wan/modules/t5.py`
- `python - <<'PY'
import wan.text2video
import wan.image2video
import wan.textimage2video
import wan.modules.t5
PY` *(fails: ModuleNotFoundError: No module named 'einops')*


------
https://chatgpt.com/codex/tasks/task_e_68abf66a77588320a356ca536b1f161a