### PR TITLE
Add device-aware distributed backend selection

### DIFF
--- a/wan/distributed/util.py
+++ b/wan/distributed/util.py
@@ -1,13 +1,23 @@
 # Copyright 2024-2025 The Alibaba Wan Team Authors. All rights reserved.
+import os
 import torch
 import torch.distributed as dist
 
 
-def init_distributed_group():
-    """r initialize sequence parallel group.
+def init_distributed_group(backend: str | None = None):
+    """Initialize sequence parallel group.
+
+    The backend can be specified via argument or WAN_BACKEND environment
+    variable. When neither is provided, defaults to ``'nccl'`` if CUDA is
+    available, otherwise ``'gloo'``.
     """
+    if backend is None:
+        backend = (
+            os.getenv("WAN_BACKEND")
+            or ("nccl" if torch.cuda.is_available() else "gloo")
+        )
     if not dist.is_initialized():
-        dist.init_process_group(backend='nccl')
+        dist.init_process_group(backend=backend)
 
 
 def get_rank():


### PR DESCRIPTION
## Summary
- add `--dist_backend` CLI option to select or override distributed backend
- guard `torch.cuda.set_device` and select `'gloo'` when CUDA is unavailable
- allow `WAN_BACKEND` env or argument to configure backend in utility helpers

## Testing
- `python -m pytest`
- `python generate.py --help` *(fails: ModuleNotFoundError: No module named 'torch')*
- `pip install torch==2.4.0` *(fails: Operation cancelled by user)*

------
https://chatgpt.com/codex/tasks/task_e_68abf67187948320b4d6107d1598cb08