### PR TITLE
Use torch.autocast with device type

### DIFF
--- a/wan/text2video.py
+++ b/wan/text2video.py
@@ -10,8 +10,8 @@ from contextlib import contextmanager
 from functools import partial
 
 import torch
-import torch.cuda.amp as amp
 import torch.distributed as dist
+from torch import autocast
 from tqdm import tqdm
 
 from .distributed.fsdp import shard_model
@@ -93,9 +93,9 @@ class WanT2V:
 
         self.vae_stride = config.vae_stride
         self.patch_size = config.patch_size
-        self.vae = Wan2_1_VAE(
-            vae_pth=os.path.join(checkpoint_dir, config.vae_checkpoint),
-            device=self.device)
+        self.vae = Wan2_1_VAE(vae_pth=os.path.join(checkpoint_dir,
+                                                   config.vae_checkpoint),
+                              device=self.device)
 
         logging.info(f"Creating WanModel from {checkpoint_dir}")
         self.low_noise_model = WanModel.from_pretrained(
@@ -250,7 +250,8 @@ class WanT2V:
         guide_scale = (guide_scale, guide_scale) if isinstance(
             guide_scale, float) else guide_scale
         F = frame_num
-        target_shape = (self.vae.model.z_dim, (F - 1) // self.vae_stride[0] + 1,
+        target_shape = (self.vae.model.z_dim,
+                        (F - 1) // self.vae_stride[0] + 1,
                         size[1] // self.vae_stride[1],
                         size[0] // self.vae_stride[2])
 
@@ -277,14 +278,13 @@ class WanT2V:
             context_null = [t.to(self.device) for t in context_null]
 
         noise = [
-            torch.randn(
-                target_shape[0],
-                target_shape[1],
-                target_shape[2],
-                target_shape[3],
-                dtype=torch.float32,
-                device=self.device,
-                generator=seed_g)
+            torch.randn(target_shape[0],
+                        target_shape[1],
+                        target_shape[2],
+                        target_shape[3],
+                        dtype=torch.float32,
+                        device=self.device,
+                        generator=seed_g)
         ]
 
         @contextmanager
@@ -298,7 +298,7 @@ class WanT2V:
 
         # evaluation mode
         with (
-                torch.amp.autocast('cuda', dtype=self.param_dtype),
+                autocast(device_type=self.device.type, dtype=self.param_dtype),
                 torch.no_grad(),
                 no_sync_low_noise(),
                 no_sync_high_noise(),
@@ -310,8 +310,9 @@ class WanT2V:
                     num_train_timesteps=self.num_train_timesteps,
                     shift=1,
                     use_dynamic_shifting=False)
-                sample_scheduler.set_timesteps(
-                    sampling_steps, device=self.device, shift=shift)
+                sample_scheduler.set_timesteps(sampling_steps,
+                                               device=self.device,
+                                               shift=shift)
                 timesteps = sample_scheduler.timesteps
             elif sample_solver == 'dpm++':
                 sample_scheduler = FlowDPMSolverMultistepScheduler(
@@ -319,10 +320,9 @@ class WanT2V:
                     shift=1,
                     use_dynamic_shifting=False)
                 sampling_sigmas = get_sampling_sigmas(sampling_steps, shift)
-                timesteps, _ = retrieve_timesteps(
-                    sample_scheduler,
-                    device=self.device,
-                    sigmas=sampling_sigmas)
+                timesteps, _ = retrieve_timesteps(sample_scheduler,
+                                                  device=self.device,
+                                                  sigmas=sampling_sigmas)
             else:
                 raise NotImplementedError("Unsupported solver.")
 
@@ -343,20 +343,21 @@ class WanT2V:
                 sample_guide_scale = guide_scale[1] if t.item(
                 ) >= boundary else guide_scale[0]
 
-                noise_pred_cond = model(
-                    latent_model_input, t=timestep, **arg_c)[0]
-                noise_pred_uncond = model(
-                    latent_model_input, t=timestep, **arg_null)[0]
+                noise_pred_cond = model(latent_model_input,
+                                        t=timestep,
+                                        **arg_c)[0]
+                noise_pred_uncond = model(latent_model_input,
+                                          t=timestep,
+                                          **arg_null)[0]
 
                 noise_pred = noise_pred_uncond + sample_guide_scale * (
                     noise_pred_cond - noise_pred_uncond)
 
-                temp_x0 = sample_scheduler.step(
-                    noise_pred.unsqueeze(0),
-                    t,
-                    latents[0].unsqueeze(0),
-                    return_dict=False,
-                    generator=seed_g)[0]
+                temp_x0 = sample_scheduler.step(noise_pred.unsqueeze(0),
+                                                t,
+                                                latents[0].unsqueeze(0),
+                                                return_dict=False,
+                                                generator=seed_g)[0]
                 latents = [temp_x0.squeeze(0)]
 
             x0 = latents

--- a/wan/textimage2video.py
+++ b/wan/textimage2video.py
@@ -10,10 +10,10 @@ from contextlib import contextmanager
 from functools import partial
 
 import torch
-import torch.cuda.amp as amp
 import torch.distributed as dist
 import torchvision.transforms.functional as TF
 from PIL import Image
+from torch import autocast
 from tqdm import tqdm
 
 from .distributed.fsdp import shard_model
@@ -95,9 +95,9 @@ class WanTI2V:
 
         self.vae_stride = config.vae_stride
         self.patch_size = config.patch_size
-        self.vae = Wan2_2_VAE(
-            vae_pth=os.path.join(checkpoint_dir, config.vae_checkpoint),
-            device=self.device)
+        self.vae = Wan2_2_VAE(vae_pth=os.path.join(checkpoint_dir,
+                                                   config.vae_checkpoint),
+                              device=self.device)
 
         logging.info(f"Creating WanModel from {checkpoint_dir}")
         self.model = WanModel.from_pretrained(checkpoint_dir)
@@ -211,30 +211,28 @@ class WanTI2V:
         """
         # i2v
         if img is not None:
-            return self.i2v(
-                input_prompt=input_prompt,
-                img=img,
-                max_area=max_area,
-                frame_num=frame_num,
-                shift=shift,
-                sample_solver=sample_solver,
-                sampling_steps=sampling_steps,
-                guide_scale=guide_scale,
-                n_prompt=n_prompt,
-                seed=seed,
-                offload_model=offload_model)
+            return self.i2v(input_prompt=input_prompt,
+                            img=img,
+                            max_area=max_area,
+                            frame_num=frame_num,
+                            shift=shift,
+                            sample_solver=sample_solver,
+                            sampling_steps=sampling_steps,
+                            guide_scale=guide_scale,
+                            n_prompt=n_prompt,
+                            seed=seed,
+                            offload_model=offload_model)
         # t2v
-        return self.t2v(
-            input_prompt=input_prompt,
-            size=size,
-            frame_num=frame_num,
-            shift=shift,
-            sample_solver=sample_solver,
-            sampling_steps=sampling_steps,
-            guide_scale=guide_scale,
-            n_prompt=n_prompt,
-            seed=seed,
-            offload_model=offload_model)
+        return self.t2v(input_prompt=input_prompt,
+                        size=size,
+                        frame_num=frame_num,
+                        shift=shift,
+                        sample_solver=sample_solver,
+                        sampling_steps=sampling_steps,
+                        guide_scale=guide_scale,
+                        n_prompt=n_prompt,
+                        seed=seed,
+                        offload_model=offload_model)
 
     def t2v(self,
             input_prompt,
@@ -282,7 +280,8 @@ class WanTI2V:
         """
         # preprocess
         F = frame_num
-        target_shape = (self.vae.model.z_dim, (F - 1) // self.vae_stride[0] + 1,
+        target_shape = (self.vae.model.z_dim,
+                        (F - 1) // self.vae_stride[0] + 1,
                         size[1] // self.vae_stride[1],
                         size[0] // self.vae_stride[2])
 
@@ -309,14 +308,13 @@ class WanTI2V:
             context_null = [t.to(self.device) for t in context_null]
 
         noise = [
-            torch.randn(
-                target_shape[0],
-                target_shape[1],
-                target_shape[2],
-                target_shape[3],
-                dtype=torch.float32,
-                device=self.device,
-                generator=seed_g)
+            torch.randn(target_shape[0],
+                        target_shape[1],
+                        target_shape[2],
+                        target_shape[3],
+                        dtype=torch.float32,
+                        device=self.device,
+                        generator=seed_g)
         ]
 
         @contextmanager
@@ -327,7 +325,7 @@ class WanTI2V:
 
         # evaluation mode
         with (
-                torch.amp.autocast('cuda', dtype=self.param_dtype),
+                autocast(device_type=self.device.type, dtype=self.param_dtype),
                 torch.no_grad(),
                 no_sync(),
         ):
@@ -337,8 +335,9 @@ class WanTI2V:
                     num_train_timesteps=self.num_train_timesteps,
                     shift=1,
                     use_dynamic_shifting=False)
-                sample_scheduler.set_timesteps(
-                    sampling_steps, device=self.device, shift=shift)
+                sample_scheduler.set_timesteps(sampling_steps,
+                                               device=self.device,
+                                               shift=shift)
                 timesteps = sample_scheduler.timesteps
             elif sample_solver == 'dpm++':
                 sample_scheduler = FlowDPMSolverMultistepScheduler(
@@ -346,10 +345,9 @@ class WanTI2V:
                     shift=1,
                     use_dynamic_shifting=False)
                 sampling_sigmas = get_sampling_sigmas(sampling_steps, shift)
-                timesteps, _ = retrieve_timesteps(
-                    sample_scheduler,
-                    device=self.device,
-                    sigmas=sampling_sigmas)
+                timesteps, _ = retrieve_timesteps(sample_scheduler,
+                                                  device=self.device,
+                                                  sigmas=sampling_sigmas)
             else:
                 raise NotImplementedError("Unsupported solver.")
 
@@ -377,20 +375,21 @@ class WanTI2V:
                 ])
                 timestep = temp_ts.unsqueeze(0)
 
-                noise_pred_cond = self.model(
-                    latent_model_input, t=timestep, **arg_c)[0]
-                noise_pred_uncond = self.model(
-                    latent_model_input, t=timestep, **arg_null)[0]
+                noise_pred_cond = self.model(latent_model_input,
+                                             t=timestep,
+                                             **arg_c)[0]
+                noise_pred_uncond = self.model(latent_model_input,
+                                               t=timestep,
+                                               **arg_null)[0]
 
                 noise_pred = noise_pred_uncond + guide_scale * (
                     noise_pred_cond - noise_pred_uncond)
 
-                temp_x0 = sample_scheduler.step(
-                    noise_pred.unsqueeze(0),
-                    t,
-                    latents[0].unsqueeze(0),
-                    return_dict=False,
-                    generator=seed_g)[0]
+                temp_x0 = sample_scheduler.step(noise_pred.unsqueeze(0),
+                                                t,
+                                                latents[0].unsqueeze(0),
+                                                return_dict=False,
+                                                generator=seed_g)[0]
                 latents = [temp_x0.squeeze(0)]
             x0 = latents
             if offload_model:
@@ -474,7 +473,8 @@ class WanTI2V:
         assert img.width == ow and img.height == oh
 
         # to tensor
-        img = TF.to_tensor(img).sub_(0.5).div_(0.5).to(self.device).unsqueeze(1)
+        img = TF.to_tensor(img).sub_(0.5).div_(0.5).to(
+            self.device).unsqueeze(1)
 
         F = frame_num
         seq_len = ((F - 1) // self.vae_stride[0] + 1) * (
@@ -485,13 +485,13 @@ class WanTI2V:
         seed = seed if seed >= 0 else random.randint(0, sys.maxsize)
         seed_g = torch.Generator(device=self.device)
         seed_g.manual_seed(seed)
-        noise = torch.randn(
-            self.vae.model.z_dim, (F - 1) // self.vae_stride[0] + 1,
-            oh // self.vae_stride[1],
-            ow // self.vae_stride[2],
-            dtype=torch.float32,
-            generator=seed_g,
-            device=self.device)
+        noise = torch.randn(self.vae.model.z_dim,
+                            (F - 1) // self.vae_stride[0] + 1,
+                            oh // self.vae_stride[1],
+                            ow // self.vae_stride[2],
+                            dtype=torch.float32,
+                            generator=seed_g,
+                            device=self.device)
 
         if n_prompt == "":
             n_prompt = self.sample_neg_prompt
@@ -519,7 +519,7 @@ class WanTI2V:
 
         # evaluation mode
         with (
-                torch.amp.autocast('cuda', dtype=self.param_dtype),
+                autocast(device_type=self.device.type, dtype=self.param_dtype),
                 torch.no_grad(),
                 no_sync(),
         ):
@@ -529,8 +529,9 @@ class WanTI2V:
                     num_train_timesteps=self.num_train_timesteps,
                     shift=1,
                     use_dynamic_shifting=False)
-                sample_scheduler.set_timesteps(
-                    sampling_steps, device=self.device, shift=shift)
+                sample_scheduler.set_timesteps(sampling_steps,
+                                               device=self.device,
+                                               shift=shift)
                 timesteps = sample_scheduler.timesteps
             elif sample_solver == 'dpm++':
                 sample_scheduler = FlowDPMSolverMultistepScheduler(
@@ -538,10 +539,9 @@ class WanTI2V:
                     shift=1,
                     use_dynamic_shifting=False)
                 sampling_sigmas = get_sampling_sigmas(sampling_steps, shift)
-                timesteps, _ = retrieve_timesteps(
-                    sample_scheduler,
-                    device=self.device,
-                    sigmas=sampling_sigmas)
+                timesteps, _ = retrieve_timesteps(sample_scheduler,
+                                                  device=self.device,
+                                                  sigmas=sampling_sigmas)
             else:
                 raise NotImplementedError("Unsupported solver.")
 
@@ -577,23 +577,24 @@ class WanTI2V:
                 ])
                 timestep = temp_ts.unsqueeze(0)
 
-                noise_pred_cond = self.model(
-                    latent_model_input, t=timestep, **arg_c)[0]
+                noise_pred_cond = self.model(latent_model_input,
+                                             t=timestep,
+                                             **arg_c)[0]
                 if offload_model:
                     torch.cuda.empty_cache()
-                noise_pred_uncond = self.model(
-                    latent_model_input, t=timestep, **arg_null)[0]
+                noise_pred_uncond = self.model(latent_model_input,
+                                               t=timestep,
+                                               **arg_null)[0]
                 if offload_model:
                     torch.cuda.empty_cache()
                 noise_pred = noise_pred_uncond + guide_scale * (
                     noise_pred_cond - noise_pred_uncond)
 
-                temp_x0 = sample_scheduler.step(
-                    noise_pred.unsqueeze(0),
-                    t,
-                    latent.unsqueeze(0),
-                    return_dict=False,
-                    generator=seed_g)[0]
+                temp_x0 = sample_scheduler.step(noise_pred.unsqueeze(0),
+                                                t,
+                                                latent.unsqueeze(0),
+                                                return_dict=False,
+                                                generator=seed_g)[0]
                 latent = temp_x0.squeeze(0)
                 latent = (1. - mask2[0]) * z[0] + mask2[0] * latent
 


### PR DESCRIPTION
## Summary
- replace deprecated `torch.cuda.amp` import with `torch.autocast`
- pass `device_type` to `autocast` so CUDA, MPS and CPU backends are supported

## Testing
- `make format`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68abf672d9f08320924ac9de07f6eb32