### PR TITLE
Guard flash_attn on macOS and update docs

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -19,6 +19,8 @@ poetry install
 
 ### Handling `flash-attn` Installation Issues
 
+macOS users can skip installing `flash_attn`.
+
 If `flash-attn` fails due to **PEP 517 build issues**, you can try one of the following fixes.
 
 #### No-Build-Isolation Installation (Recommended)

--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ cd Wan2.2
 Install dependencies:
 ```sh
 # Ensure torch >= 2.4.0
+# macOS users can skip installing `flash_attn`
 # If the installation of `flash_attn` fails, try installing the other packages first and install `flash_attn` last
 pip install -r requirements.txt
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
     "ftfy",
     "dashscope",
     "imageio-ffmpeg",
-    "flash_attn",
+    "flash_attn; platform_system != \"Darwin\"",
     "numpy>=1.23.5,<2"
 ]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,5 +11,5 @@ easydict
 ftfy
 dashscope
 imageio-ffmpeg
-flash_attn
+flash_attn; platform_system != "Darwin"
 numpy>=1.23.5,<2


### PR DESCRIPTION
## Summary
- Avoid installing `flash_attn` on macOS by adding an environment marker
- Note in README/INSTALL that macOS users can skip `flash_attn`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68abf673e8808320b193bd4497793a03