### PR TITLE
docs: add macOS installation notes

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -17,6 +17,28 @@ To install all dependencies:
 poetry install
 ```
 
+## macOS
+
+### PyTorch with MPS
+
+Install PyTorch with [MPS](https://pytorch.org/docs/stable/mps.html) support for Apple Silicon or Intel Macs:
+
+```bash
+pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cpu
+```
+
+### `ffmpeg` via Homebrew
+
+Use [Homebrew](https://brew.sh) to install `ffmpeg` for video generation:
+
+```bash
+brew install ffmpeg
+```
+
+### `flash-attn`
+
+`flash-attn` is not supported on macOS. Skip its installation or replace it with another attention implementation such as [`xformers`](https://github.com/facebookresearch/xformers).
+
 ### Handling `flash-attn` Installation Issues
 
 If `flash-attn` fails due to **PEP 517 build issues**, you can try one of the following fixes.
@@ -41,6 +63,12 @@ Once the installation is complete, you can run **Wan2.2** using:
 
 ```bash
 poetry run python generate.py --task t2v-A14B --size '1280*720' --ckpt_dir ./Wan2.2-T2V-A14B --prompt "Two anthropomorphic cats in comfy boxing gear and bright gloves fight intensely on a spotlighted stage."
+```
+
+On machines with limited GPU support (e.g. macOS), you can offload model components to the CPU:
+
+```bash
+poetry run python generate.py --task t2v-A14B --size '512*512' --ckpt_dir ./Wan2.2-T2V-A14B --prompt "Two anthropomorphic cats" --offload_model true
 ```
 
 #### Test


### PR DESCRIPTION
## Summary
- document macOS setup including MPS PyTorch, Homebrew ffmpeg, and flash-attn alternatives
- show how to run `generate.py` with `--offload_model` for CPU fallback

## Testing
- `pytest`
- `bash tests/test.sh` *(fails: Usage: tests/test.sh <local model dir> <gpu number>)*

------
https://chatgpt.com/codex/tasks/task_e_68abf675dea483209ccc0a5d28fa7e0a