### PR TITLE
Centralize device selection and remove explicit CUDA indices

### DIFF
--- a/wan/image2video.py
+++ b/wan/image2video.py
@@ -28,6 +28,7 @@ from .utils.fm_solvers import (
     retrieve_timesteps,
 )
 from .utils.fm_solvers_unipc import FlowUniPCMultistepScheduler
+from .utils.utils import get_device
 
 
 class WanI2V:
@@ -71,7 +72,7 @@ class WanI2V:
                 Convert DiT model parameters dtype to 'config.param_dtype'.
                 Only works without FSDP.
         """
-        self.device = torch.device(f"cuda:{device_id}")
+        self.device = torch.device(get_device())
         self.config = config
         self.rank = rank
         self.t5_cpu = t5_cpu
@@ -195,7 +196,7 @@ class WanI2V:
         if offload_model or self.init_on_cpu:
             if next(getattr(
                     self,
-                    offload_model_name).parameters()).device.type == 'cuda':
+                    offload_model_name).parameters()).device.type == self.device.type:
                 getattr(self, offload_model_name).to('cpu')
             if next(getattr(
                     self,
@@ -333,7 +334,7 @@ class WanI2V:
 
         # evaluation mode
         with (
-                torch.amp.autocast('cuda', dtype=self.param_dtype),
+                torch.amp.autocast(self.device.type, dtype=self.param_dtype),
                 torch.no_grad(),
                 no_sync_low_noise(),
                 no_sync_high_noise(),

--- a/wan/textimage2video.py
+++ b/wan/textimage2video.py
@@ -28,7 +28,7 @@ from .utils.fm_solvers import (
     retrieve_timesteps,
 )
 from .utils.fm_solvers_unipc import FlowUniPCMultistepScheduler
-from .utils.utils import best_output_size, masks_like
+from .utils.utils import best_output_size, masks_like, get_device
 
 
 class WanTI2V:
@@ -72,7 +72,7 @@ class WanTI2V:
                 Convert DiT model parameters dtype to 'config.param_dtype'.
                 Only works without FSDP.
         """
-        self.device = torch.device(f"cuda:{device_id}")
+        self.device = torch.device(get_device())
         self.config = config
         self.rank = rank
         self.t5_cpu = t5_cpu
@@ -327,7 +327,7 @@ class WanTI2V:
 
         # evaluation mode
         with (
-                torch.amp.autocast('cuda', dtype=self.param_dtype),
+                torch.amp.autocast(self.device.type, dtype=self.param_dtype),
                 torch.no_grad(),
                 no_sync(),
         ):
@@ -519,7 +519,7 @@ class WanTI2V:
 
         # evaluation mode
         with (
-                torch.amp.autocast('cuda', dtype=self.param_dtype),
+                torch.amp.autocast(self.device.type, dtype=self.param_dtype),
                 torch.no_grad(),
                 no_sync(),
         ):

--- a/wan/utils/utils.py
+++ b/wan/utils/utils.py
@@ -9,7 +9,21 @@ import imageio
 import torch
 import torchvision
 
-__all__ = ['save_video', 'save_image', 'str2bool']
+__all__ = ['save_video', 'save_image', 'str2bool', 'get_device']
+
+
+def get_device():
+    """Return the best available torch device.
+
+    Returns:
+        str: ``"cuda"`` if CUDA is available, ``"mps"`` if Apple's Metal
+        Performance Shaders are available, otherwise ``"cpu"``.
+    """
+    if torch.cuda.is_available():
+        return 'cuda'
+    if torch.backends.mps.is_available():
+        return 'mps'
+    return 'cpu'
 
 
 def rand_name(length=8, suffix=''):


### PR DESCRIPTION
## Summary
- add a helper `get_device` that picks CUDA, MPS, or CPU
- refactor video generation modules to use `get_device()` instead of hard-coded `cuda:0`
- use the computed device type for autocast and device checks

## Testing
- `python3 -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68abf67f52dc8320be5edb3aa77bbb69