### PR TITLE
feat: make flash_attn optional in installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,8 +76,10 @@ cd Wan2.2
 Install dependencies:
 ```sh
 # Ensure torch >= 2.4.0
-# If the installation of `flash_attn` fails, try installing the other packages first and install `flash_attn` last
 pip install -r requirements.txt
+# Optional: install flash_attn separately for faster attention kernels
+# On macOS, either skip flash_attn or manually build a compatible version
+pip install flash_attn
 ```
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,6 @@ dependencies = [
     "ftfy",
     "dashscope",
     "imageio-ffmpeg",
-    "flash_attn",
     "numpy>=1.23.5,<2"
 ]
 
@@ -38,6 +37,9 @@ dev = [
     "isort",
     "mypy",
     "huggingface-hub[cli]"
+]
+flash-attn = [
+    "flash_attn"
 ]
 
 [project.urls]

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,5 +11,4 @@ easydict
 ftfy
 dashscope
 imageio-ffmpeg
-flash_attn
 numpy>=1.23.5,<2


### PR DESCRIPTION
## Summary
- drop flash_attn from required dependencies
- expose flash_attn as optional extra and document macOS installation note

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68abf684a3f88320bb292c2159f37c7d