### PR TITLE
Wrap CUDA ops with device-aware helpers

### DIFF
--- a/generate.py
+++ b/generate.py
@@ -17,23 +17,23 @@ from PIL import Image
 import wan
 from wan.configs import MAX_AREA_CONFIGS, SIZE_CONFIGS, SUPPORTED_SIZES, WAN_CONFIGS
 from wan.distributed.util import init_distributed_group
+from wan.utils.device import device_synchronize, set_device
 from wan.utils.prompt_extend import DashScopePromptExpander, QwenPromptExpander
 from wan.utils.utils import save_video, str2bool
 
 EXAMPLE_PROMPT = {
     "t2v-A14B": {
         "prompt":
-            "Two anthropomorphic cats in comfy boxing gear and bright gloves fight intensely on a spotlighted stage.",
+        "Two anthropomorphic cats in comfy boxing gear and bright gloves fight intensely on a spotlighted stage.",
     },
     "i2v-A14B": {
         "prompt":
-            "Summer beach vacation style, a white cat wearing sunglasses sits on a surfboard. The fluffy-furred feline gazes directly at the camera with a relaxed expression. Blurred beach scenery forms the background featuring crystal-clear waters, distant green hills, and a blue sky dotted with white clouds. The cat assumes a naturally relaxed posture, as if savoring the sea breeze and warm sunlight. A close-up shot highlights the feline's intricate details and the refreshing atmosphere of the seaside.",
-        "image":
-            "examples/i2v_input.JPG",
+        "Summer beach vacation style, a white cat wearing sunglasses sits on a surfboard. The fluffy-furred feline gazes directly at the camera with a relaxed expression. Blurred beach scenery forms the background featuring crystal-clear waters, distant green hills, and a blue sky dotted with white clouds. The cat assumes a naturally relaxed posture, as if savoring the sea breeze and warm sunlight. A close-up shot highlights the feline's intricate details and the refreshing atmosphere of the seaside.",
+        "image": "examples/i2v_input.JPG",
     },
     "ti2v-5B": {
         "prompt":
-            "Two anthropomorphic cats in comfy boxing gear and bright gloves fight intensely on a spotlighted stage.",
+        "Two anthropomorphic cats in comfy boxing gear and bright gloves fight intensely on a spotlighted stage.",
     },
 }
 
@@ -76,20 +76,20 @@ def _validate_args(args):
 
 def _parse_args():
     parser = argparse.ArgumentParser(
-        description="Generate a image or video from a text prompt or image using Wan"
-    )
-    parser.add_argument(
-        "--task",
-        type=str,
-        default="t2v-A14B",
-        choices=list(WAN_CONFIGS.keys()),
-        help="The task to run.")
+        description=
+        "Generate a image or video from a text prompt or image using Wan")
+    parser.add_argument("--task",
+                        type=str,
+                        default="t2v-A14B",
+                        choices=list(WAN_CONFIGS.keys()),
+                        help="The task to run.")
     parser.add_argument(
         "--size",
         type=str,
         default="1280*720",
         choices=list(SIZE_CONFIGS.keys()),
-        help="The area (width*height) of the generated video. For the I2V task, the aspect ratio of the output video will follow that of the input image."
+        help=
+        "The area (width*height) of the generated video. For the I2V task, the aspect ratio of the output video will follow that of the input image."
     )
     parser.add_argument(
         "--frame_num",
@@ -97,102 +97,89 @@ def _parse_args():
         default=None,
         help="How many frames of video are generated. The number should be 4n+1"
     )
-    parser.add_argument(
-        "--ckpt_dir",
-        type=str,
-        default=None,
-        help="The path to the checkpoint directory.")
+    parser.add_argument("--ckpt_dir",
+                        type=str,
+                        default=None,
+                        help="The path to the checkpoint directory.")
     parser.add_argument(
         "--offload_model",
         type=str2bool,
         default=None,
-        help="Whether to offload the model to CPU after each model forward, reducing GPU memory usage."
+        help=
+        "Whether to offload the model to CPU after each model forward, reducing GPU memory usage."
     )
-    parser.add_argument(
-        "--ulysses_size",
-        type=int,
-        default=1,
-        help="The size of the ulysses parallelism in DiT.")
-    parser.add_argument(
-        "--t5_fsdp",
-        action="store_true",
-        default=False,
-        help="Whether to use FSDP for T5.")
-    parser.add_argument(
-        "--t5_cpu",
-        action="store_true",
-        default=False,
-        help="Whether to place T5 model on CPU.")
-    parser.add_argument(
-        "--dit_fsdp",
-        action="store_true",
-        default=False,
-        help="Whether to use FSDP for DiT.")
-    parser.add_argument(
-        "--save_file",
-        type=str,
-        default=None,
-        help="The file to save the generated video to.")
-    parser.add_argument(
-        "--prompt",
-        type=str,
-        default=None,
-        help="The prompt to generate the video from.")
-    parser.add_argument(
-        "--use_prompt_extend",
-        action="store_true",
-        default=False,
-        help="Whether to use prompt extend.")
-    parser.add_argument(
-        "--prompt_extend_method",
-        type=str,
-        default="local_qwen",
-        choices=["dashscope", "local_qwen"],
-        help="The prompt extend method to use.")
-    parser.add_argument(
-        "--prompt_extend_model",
-        type=str,
-        default=None,
-        help="The prompt extend model to use.")
-    parser.add_argument(
-        "--prompt_extend_target_lang",
-        type=str,
-        default="zh",
-        choices=["zh", "en"],
-        help="The target language of prompt extend.")
-    parser.add_argument(
-        "--base_seed",
-        type=int,
-        default=-1,
-        help="The seed to use for generating the video.")
-    parser.add_argument(
-        "--image",
-        type=str,
-        default=None,
-        help="The image to generate the video from.")
-    parser.add_argument(
-        "--sample_solver",
-        type=str,
-        default='unipc',
-        choices=['unipc', 'dpm++'],
-        help="The solver used to sample.")
-    parser.add_argument(
-        "--sample_steps", type=int, default=None, help="The sampling steps.")
+    parser.add_argument("--ulysses_size",
+                        type=int,
+                        default=1,
+                        help="The size of the ulysses parallelism in DiT.")
+    parser.add_argument("--t5_fsdp",
+                        action="store_true",
+                        default=False,
+                        help="Whether to use FSDP for T5.")
+    parser.add_argument("--t5_cpu",
+                        action="store_true",
+                        default=False,
+                        help="Whether to place T5 model on CPU.")
+    parser.add_argument("--dit_fsdp",
+                        action="store_true",
+                        default=False,
+                        help="Whether to use FSDP for DiT.")
+    parser.add_argument("--save_file",
+                        type=str,
+                        default=None,
+                        help="The file to save the generated video to.")
+    parser.add_argument("--prompt",
+                        type=str,
+                        default=None,
+                        help="The prompt to generate the video from.")
+    parser.add_argument("--use_prompt_extend",
+                        action="store_true",
+                        default=False,
+                        help="Whether to use prompt extend.")
+    parser.add_argument("--prompt_extend_method",
+                        type=str,
+                        default="local_qwen",
+                        choices=["dashscope", "local_qwen"],
+                        help="The prompt extend method to use.")
+    parser.add_argument("--prompt_extend_model",
+                        type=str,
+                        default=None,
+                        help="The prompt extend model to use.")
+    parser.add_argument("--prompt_extend_target_lang",
+                        type=str,
+                        default="zh",
+                        choices=["zh", "en"],
+                        help="The target language of prompt extend.")
+    parser.add_argument("--base_seed",
+                        type=int,
+                        default=-1,
+                        help="The seed to use for generating the video.")
+    parser.add_argument("--image",
+                        type=str,
+                        default=None,
+                        help="The image to generate the video from.")
+    parser.add_argument("--sample_solver",
+                        type=str,
+                        default='unipc',
+                        choices=['unipc', 'dpm++'],
+                        help="The solver used to sample.")
+    parser.add_argument("--sample_steps",
+                        type=int,
+                        default=None,
+                        help="The sampling steps.")
     parser.add_argument(
         "--sample_shift",
         type=float,
         default=None,
         help="Sampling shift factor for flow matching schedulers.")
-    parser.add_argument(
-        "--sample_guide_scale",
-        type=float,
-        default=None,
-        help="Classifier free guidance scale.")
-    parser.add_argument(
-        "--convert_model_dtype",
-        action="store_true",
-        default=False,
-        help="Whether to convert model paramerters dtype.")
+    parser.add_argument("--sample_guide_scale",
+                        type=float,
+                        default=None,
+                        help="Classifier free guidance scale.")
+    parser.add_argument("--convert_model_dtype",
+                        action="store_true",
+                        default=False,
+                        help="Whether to convert model paramerters dtype.")
 
     args = parser.parse_args()
 
@@ -217,7 +204,13 @@ def generate(args):
     rank = int(os.getenv("RANK", 0))
     world_size = int(os.getenv("WORLD_SIZE", 1))
     local_rank = int(os.getenv("LOCAL_RANK", 0))
-    device = local_rank
+    device_id = local_rank
+    if torch.cuda.is_available():
+        device = torch.device(f"cuda:{device_id}")
+    elif hasattr(torch, "mps") and torch.backends.mps.is_available():
+        device = torch.device("mps")
+    else:
+        device = torch.device("cpu")
     _init_logging(rank)
 
     if args.offload_model is None:
@@ -225,12 +218,11 @@ def generate(args):
         logging.info(
             f"offload_model is not specified, set to {args.offload_model}.")
     if world_size > 1:
-        torch.cuda.set_device(local_rank)
-        dist.init_process_group(
-            backend="nccl",
-            init_method="env://",
-            rank=rank,
-            world_size=world_size)
+        set_device(device)
+        dist.init_process_group(backend="nccl",
+                                init_method="env://",
+                                rank=rank,
+                                world_size=world_size)
     else:
         assert not (
             args.t5_fsdp or args.dit_fsdp
@@ -306,7 +298,7 @@ def generate(args):
         wan_t2v = wan.WanT2V(
             config=cfg,
             checkpoint_dir=args.ckpt_dir,
-            device_id=device,
+            device_id=device_id,
             rank=rank,
             t5_fsdp=args.t5_fsdp,
             dit_fsdp=args.dit_fsdp,
@@ -316,22 +308,21 @@ def generate(args):
         )
 
         logging.info(f"Generating video ...")
-        video = wan_t2v.generate(
-            args.prompt,
-            size=SIZE_CONFIGS[args.size],
-            frame_num=args.frame_num,
-            shift=args.sample_shift,
-            sample_solver=args.sample_solver,
-            sampling_steps=args.sample_steps,
-            guide_scale=args.sample_guide_scale,
-            seed=args.base_seed,
-            offload_model=args.offload_model)
+        video = wan_t2v.generate(args.prompt,
+                                 size=SIZE_CONFIGS[args.size],
+                                 frame_num=args.frame_num,
+                                 shift=args.sample_shift,
+                                 sample_solver=args.sample_solver,
+                                 sampling_steps=args.sample_steps,
+                                 guide_scale=args.sample_guide_scale,
+                                 seed=args.base_seed,
+                                 offload_model=args.offload_model)
     elif "ti2v" in args.task:
         logging.info("Creating WanTI2V pipeline.")
         wan_ti2v = wan.WanTI2V(
             config=cfg,
             checkpoint_dir=args.ckpt_dir,
-            device_id=device,
+            device_id=device_id,
             rank=rank,
             t5_fsdp=args.t5_fsdp,
             dit_fsdp=args.dit_fsdp,
@@ -341,24 +332,23 @@ def generate(args):
         )
 
         logging.info(f"Generating video ...")
-        video = wan_ti2v.generate(
-            args.prompt,
-            img=img,
-            size=SIZE_CONFIGS[args.size],
-            max_area=MAX_AREA_CONFIGS[args.size],
-            frame_num=args.frame_num,
-            shift=args.sample_shift,
-            sample_solver=args.sample_solver,
-            sampling_steps=args.sample_steps,
-            guide_scale=args.sample_guide_scale,
-            seed=args.base_seed,
-            offload_model=args.offload_model)
+        video = wan_ti2v.generate(args.prompt,
+                                  img=img,
+                                  size=SIZE_CONFIGS[args.size],
+                                  max_area=MAX_AREA_CONFIGS[args.size],
+                                  frame_num=args.frame_num,
+                                  shift=args.sample_shift,
+                                  sample_solver=args.sample_solver,
+                                  sampling_steps=args.sample_steps,
+                                  guide_scale=args.sample_guide_scale,
+                                  seed=args.base_seed,
+                                  offload_model=args.offload_model)
     else:
         logging.info("Creating WanI2V pipeline.")
         wan_i2v = wan.WanI2V(
             config=cfg,
             checkpoint_dir=args.ckpt_dir,
-            device_id=device,
+            device_id=device_id,
             rank=rank,
             t5_fsdp=args.t5_fsdp,
             dit_fsdp=args.dit_fsdp,
@@ -368,17 +358,16 @@ def generate(args):
         )
 
         logging.info("Generating video ...")
-        video = wan_i2v.generate(
-            args.prompt,
-            img,
-            max_area=MAX_AREA_CONFIGS[args.size],
-            frame_num=args.frame_num,
-            shift=args.sample_shift,
-            sample_solver=args.sample_solver,
-            sampling_steps=args.sample_steps,
-            guide_scale=args.sample_guide_scale,
-            seed=args.base_seed,
-            offload_model=args.offload_model)
+        video = wan_i2v.generate(args.prompt,
+                                 img,
+                                 max_area=MAX_AREA_CONFIGS[args.size],
+                                 frame_num=args.frame_num,
+                                 shift=args.sample_shift,
+                                 sample_solver=args.sample_solver,
+                                 sampling_steps=args.sample_steps,
+                                 guide_scale=args.sample_guide_scale,
+                                 seed=args.base_seed,
+                                 offload_model=args.offload_model)
 
     if rank == 0:
         if args.save_file is None:
@@ -389,16 +378,15 @@ def generate(args):
             args.save_file = f"{args.task}_{args.size.replace('*','x') if sys.platform=='win32' else args.size}_{args.ulysses_size}_{formatted_prompt}_{formatted_time}" + suffix
 
         logging.info(f"Saving generated video to {args.save_file}")
-        save_video(
-            tensor=video[None],
-            save_file=args.save_file,
-            fps=cfg.sample_fps,
-            nrow=1,
-            normalize=True,
-            value_range=(-1, 1))
+        save_video(tensor=video[None],
+                   save_file=args.save_file,
+                   fps=cfg.sample_fps,
+                   nrow=1,
+                   normalize=True,
+                   value_range=(-1, 1))
     del video
 
-    torch.cuda.synchronize()
+    device_synchronize(device)
     if dist.is_initialized():
         dist.barrier()
         dist.destroy_process_group()

--- a/wan/utils/device.py
+++ b/wan/utils/device.py
@@ -1,0 +1,31 @@
+import torch
+
+
+def device_synchronize(device):
+    """Synchronize operations on the given device if supported."""
+    if device.type == "cuda":
+        torch.cuda.synchronize()
+    elif device.type == "mps":
+        torch.mps.synchronize()
+
+
+def empty_cache(device):
+    """Empty cache for the given device if supported."""
+    if device.type == "cuda":
+        torch.cuda.empty_cache()
+    elif device.type == "mps":
+        torch.mps.empty_cache()
+
+
+def set_device(device):
+    """Set the current device."""
+    if isinstance(device, torch.device):
+        if device.type == "cuda":
+            torch.cuda.set_device(device)
+        elif device.type == "mps":
+            torch.mps.set_device(device)
+    else:
+        if torch.cuda.is_available():
+            torch.cuda.set_device(device)
+        elif hasattr(torch, "mps") and torch.backends.mps.is_available():
+            torch.mps.set_device(device)


### PR DESCRIPTION
## Summary
- add `device_synchronize`, `empty_cache`, and `set_device` helpers to abstract CUDA/MPS handling
- refactor generation scripts to use the device helpers instead of direct `torch.cuda` calls
- update FSDP cleanup to respect device-specific cache clearing

## Testing
- `isort generate.py wan/distributed/fsdp.py wan/image2video.py wan/text2video.py wan/textimage2video.py wan/utils/device.py`
- `yapf -i generate.py wan/distributed/fsdp.py wan/image2video.py wan/text2video.py wan/textimage2video.py wan/utils/device.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68abf694a4bc8320ac1f8b1b4a92939d