### PR TITLE
Handle non-CUDA distributed environments

### DIFF
--- a/generate.py
+++ b/generate.py
@@ -225,9 +225,11 @@ def generate(args):
         logging.info(
             f"offload_model is not specified, set to {args.offload_model}.")
     if world_size > 1:
-        torch.cuda.set_device(local_rank)
+        backend = "nccl" if torch.cuda.is_available() else "gloo"
+        if backend == "nccl":
+            torch.cuda.set_device(local_rank)
         dist.init_process_group(
-            backend="nccl",
+            backend=backend,
             init_method="env://",
             rank=rank,
             world_size=world_size)


### PR DESCRIPTION
## Summary
- detect appropriate distributed backend based on CUDA availability
- skip torch.cuda.set_device when using CPU/MPS backends

## Testing
- `python -m py_compile generate.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68abf6982b388320b76b48a0ebd54a77