### PR TITLE
Make flash_attn optional for macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,9 +76,13 @@ cd Wan2.2
 Install dependencies:
 ```sh
 # Ensure torch >= 2.4.0
-# If the installation of `flash_attn` fails, try installing the other packages first and install `flash_attn` last
+# Install core dependencies
 pip install -r requirements.txt
+# Optional: install FlashAttention for faster attention kernels
+# pip install -r extras/flash_attn.txt
 ```
+
+> **macOS users**: `flash_attn` can be omitted. Without it, Wan2.2 falls back to the standard PyTorch attention implementation.
 
 
 #### Model Download

--- a/extras/flash_attn.txt
+++ b/extras/flash_attn.txt
@@ -1,0 +1,1 @@
+flash_attn

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,6 @@ dependencies = [
     "ftfy",
     "dashscope",
     "imageio-ffmpeg",
-    "flash_attn",
     "numpy>=1.23.5,<2"
 ]
 
@@ -38,6 +37,9 @@ dev = [
     "isort",
     "mypy",
     "huggingface-hub[cli]"
+]
+flash-attn = [
+    "flash_attn"
 ]
 
 [project.urls]

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,5 +11,4 @@ easydict
 ftfy
 dashscope
 imageio-ffmpeg
-flash_attn
 numpy>=1.23.5,<2


### PR DESCRIPTION
## Summary
- remove flash_attn from base requirements and move to extras
- document optional FlashAttention install and macOS fallback to standard attention
- expose flash_attn as an optional dependency in pyproject

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68abf69959848320b417d17115d7cf6f