### PR TITLE
docs: add macOS installation notes and flash_attn caveats

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -17,6 +17,22 @@ To install all dependencies:
 poetry install
 ```
 
+## macOS
+
+On macOS, install `ffmpeg` using [Homebrew](https://brew.sh/) and use the CPU build of PyTorch (which enables the MPS backend on Apple Silicon):
+
+```bash
+brew install ffmpeg
+pip install torch torchvision --index-url https://download.pytorch.org/whl/cpu
+```
+
+Before enabling MPS acceleration, verify it is available:
+
+```python
+import torch
+torch.backends.mps.is_available()
+```
+
 ### Handling `flash-attn` Installation Issues
 
 If `flash-attn` fails due to **PEP 517 build issues**, you can try one of the following fixes.
@@ -32,6 +48,8 @@ poetry install
 ```bash
 poetry run pip install git+https://github.com/Dao-AILab/flash-attention.git
 ```
+
+> ⚠️ Skipping `flash-attn` causes the code to fall back to PyTorch's `scaled_dot_product_attention`, disabling padding masks and slowing down attention operations.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -80,6 +80,24 @@ Install dependencies:
 pip install -r requirements.txt
 ```
 
+> ⚠️ Without `flash_attn`, the code falls back to PyTorch's `scaled_dot_product_attention`, which disables padding masks and can be significantly slower.
+
+#### macOS
+
+On macOS, install system and Python dependencies with Homebrew and pip:
+
+```bash
+brew install ffmpeg
+pip install torch torchvision --index-url https://download.pytorch.org/whl/cpu
+```
+
+If you plan to use the Metal Performance Shaders (MPS) backend on Apple Silicon, verify that it is available before enabling it:
+
+```python
+import torch
+torch.backends.mps.is_available()
+```
+
 
 #### Model Download
 


### PR DESCRIPTION
## Summary
- document macOS setup using Homebrew ffmpeg, CPU PyTorch wheels, and MPS check
- warn about fallback behavior when `flash_attn` is not installed

## Testing
- `pytest -q`
- `bash tests/test.sh foo 1` *(fails: torchrun: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68abf69aefd88320866b2088b19611df