### PR TITLE
Add device-agnostic cache and sync wrappers

### DIFF
--- a/generate.py
+++ b/generate.py
@@ -19,6 +19,7 @@ from wan.configs import MAX_AREA_CONFIGS, SIZE_CONFIGS, SUPPORTED_SIZES, WAN_CON
 from wan.distributed.util import init_distributed_group
 from wan.utils.prompt_extend import DashScopePromptExpander, QwenPromptExpander
 from wan.utils.utils import save_video, str2bool
+from wan.utils.device import synchronize_device
 
 EXAMPLE_PROMPT = {
     "t2v-A14B": {
@@ -410,7 +411,7 @@ def generate(args):
             value_range=(-1, 1))
     del video
 
-    torch.cuda.synchronize()
+    synchronize_device()
     if dist.is_initialized():
         dist.barrier()
         dist.destroy_process_group()

--- a/wan/distributed/fsdp.py
+++ b/wan/distributed/fsdp.py
@@ -8,6 +8,8 @@ from torch.distributed.fsdp import MixedPrecision, ShardingStrategy
 from torch.distributed.fsdp.wrap import lambda_auto_wrap_policy
 from torch.distributed.utils import _free_storage
 
+from ..utils.device import empty_device_cache
+
 
 def shard_model(
     model,
@@ -40,4 +42,4 @@ def free_model(model):
             _free_storage(m._handle.flat_param.data)
     del model
     gc.collect()
-    torch.cuda.empty_cache()
+    empty_device_cache()

--- a/wan/text2video.py
+++ b/wan/text2video.py
@@ -26,6 +26,7 @@ from .utils.fm_solvers import (
     retrieve_timesteps,
 )
 from .utils.fm_solvers_unipc import FlowUniPCMultistepScheduler
+from .utils.device import empty_device_cache, synchronize_device
 
 
 class WanT2V:
@@ -369,7 +370,7 @@ class WanT2V:
             if offload_model:
                 self.low_noise_model.cpu()
                 self.high_noise_model.cpu()
-                torch.cuda.empty_cache()
+                empty_device_cache()
             if self.rank == 0:
                 videos = self.vae.decode(x0)
 
@@ -377,7 +378,7 @@ class WanT2V:
         del sample_scheduler
         if offload_model:
             gc.collect()
-            torch.cuda.synchronize()
+            synchronize_device()
         if dist.is_initialized():
             dist.barrier()
 

--- a/wan/utils/device.py
+++ b/wan/utils/device.py
@@ -1,0 +1,51 @@
+# Copyright 2024-2025 The Alibaba Wan Team Authors. All rights reserved.
+"""Utility helpers for device specific operations.
+
+This module provides wrappers around device specific cache clearing and
+synchronization to seamlessly support CUDA, MPS and CPU execution.
+"""
+
+from __future__ import annotations
+
+import torch
+
+__all__ = ["empty_device_cache", "synchronize_device"]
+
+
+def _default_device() -> torch.device:
+    """Return the best available device."""
+    if torch.cuda.is_available():
+        return torch.device("cuda")
+    if torch.backends.mps.is_available():
+        return torch.device("mps")
+    return torch.device("cpu")
+
+
+def empty_device_cache(device: str | torch.device | None = None) -> None:
+    """Release cached memory on the given device.
+
+    Args:
+        device: Optional device specification. When ``None`` the best
+            available device is used.
+    """
+    dev = torch.device(device) if device is not None else _default_device()
+    if dev.type == "cuda":
+        torch.cuda.empty_cache()
+    elif dev.type == "mps" and hasattr(torch, "mps") and hasattr(torch.mps, "empty_cache"):
+        torch.mps.empty_cache()
+    # CPU requires no action
+
+
+def synchronize_device(device: str | torch.device | None = None) -> None:
+    """Synchronize the given device if necessary.
+
+    Args:
+        device: Optional device specification. When ``None`` the best
+            available device is used.
+    """
+    dev = torch.device(device) if device is not None else _default_device()
+    if dev.type == "cuda":
+        torch.cuda.synchronize()
+    elif dev.type == "mps" and hasattr(torch, "mps") and hasattr(torch.mps, "synchronize"):
+        torch.mps.synchronize()
+    # CPU requires no action


### PR DESCRIPTION
## Summary
- Abstract device cache clearing and synchronization into helpers
- Replace direct CUDA calls with device-aware wrappers across modules

## Testing
- `python -m py_compile wan/utils/device.py wan/distributed/fsdp.py wan/image2video.py wan/text2video.py wan/textimage2video.py generate.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68abfd9b3f4c8320bafb5c41d2968f95