### PR TITLE
refactor device cache handling

### DIFF
--- a/wan/distributed/fsdp.py
+++ b/wan/distributed/fsdp.py
@@ -8,6 +8,8 @@ from torch.distributed.fsdp import MixedPrecision, ShardingStrategy
 from torch.distributed.fsdp.wrap import lambda_auto_wrap_policy
 from torch.distributed.utils import _free_storage
 
+from ..utils.device import empty_device_cache
+
 
 def shard_model(
     model,
@@ -19,18 +21,17 @@ def shard_model(
     sharding_strategy=ShardingStrategy.FULL_SHARD,
     sync_module_states=True,
 ):
-    model = FSDP(
-        module=model,
-        process_group=process_group,
-        sharding_strategy=sharding_strategy,
-        auto_wrap_policy=partial(
-            lambda_auto_wrap_policy, lambda_fn=lambda m: m in model.blocks),
-        mixed_precision=MixedPrecision(
-            param_dtype=param_dtype,
-            reduce_dtype=reduce_dtype,
-            buffer_dtype=buffer_dtype),
-        device_id=device_id,
-        sync_module_states=sync_module_states)
+    model = FSDP(module=model,
+                 process_group=process_group,
+                 sharding_strategy=sharding_strategy,
+                 auto_wrap_policy=partial(
+                     lambda_auto_wrap_policy,
+                     lambda_fn=lambda m: m in model.blocks),
+                 mixed_precision=MixedPrecision(param_dtype=param_dtype,
+                                                reduce_dtype=reduce_dtype,
+                                                buffer_dtype=buffer_dtype),
+                 device_id=device_id,
+                 sync_module_states=sync_module_states)
     return model
 
 
@@ -40,4 +41,4 @@ def free_model(model):
             _free_storage(m._handle.flat_param.data)
     del model
     gc.collect()
-    torch.cuda.empty_cache()
+    empty_device_cache()

--- a/wan/utils/__init__.py
+++ b/wan/utils/__init__.py
@@ -1,4 +1,5 @@
 # Copyright 2024-2025 The Alibaba Wan Team Authors. All rights reserved.
+from .device import empty_device_cache, get_default_device
 from .fm_solvers import (
     FlowDPMSolverMultistepScheduler,
     get_sampling_sigmas,
@@ -8,5 +9,6 @@ from .fm_solvers_unipc import FlowUniPCMultistepScheduler
 
 __all__ = [
     'HuggingfaceTokenizer', 'get_sampling_sigmas', 'retrieve_timesteps',
-    'FlowDPMSolverMultistepScheduler', 'FlowUniPCMultistepScheduler'
+    'FlowDPMSolverMultistepScheduler', 'FlowUniPCMultistepScheduler',
+    'get_default_device', 'empty_device_cache'
 ]

--- a/wan/utils/device.py
+++ b/wan/utils/device.py
@@ -1,0 +1,25 @@
+import torch
+
+
+def get_default_device(device_id: int = 0) -> torch.device:
+    """Return the default torch.device for the current environment.
+
+    The function prefers CUDA when available, then Apple's MPS backend,
+    and finally CPU.
+    """
+    if torch.cuda.is_available():
+        return torch.device(f"cuda:{device_id}")
+    if torch.backends.mps.is_available():
+        return torch.device("mps")
+    return torch.device("cpu")
+
+
+def empty_device_cache() -> None:
+    """Free cached memory of the current accelerator if needed."""
+    if torch.cuda.is_available():
+        torch.cuda.empty_cache()
+    elif torch.backends.mps.is_available():
+        # torch.mps may not expose empty_cache on older versions
+        empty = getattr(torch.mps, "empty_cache", None)
+        if callable(empty):
+            empty()


### PR DESCRIPTION
## Summary
- add device-aware helpers in `wan/utils/device.py`
- replace `torch.cuda.empty_cache()` with `empty_device_cache()` in FSDP cleanup
- export new helpers via `wan.utils`

## Testing
- `make format`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68abfd9c0a5c8320bbd241509b50adea