### PR TITLE
Use automatic device selection for VAE initialization

### DIFF
--- a/wan/modules/vae2_1.py
+++ b/wan/modules/vae2_1.py
@@ -7,6 +7,8 @@ import torch.nn.functional as F
 from einops import rearrange
 from torch import autocast
 
+from ..utils.utils import get_best_device
+
 __all__ = [
     'Wan2_1_VAE',
 ]
@@ -616,8 +618,10 @@ class Wan2_1_VAE:
                  z_dim=16,
                  vae_pth='cache/vae_step_411000.pth',
                  dtype=torch.float,
-                 device="cuda"):
+                 device=None):
         self.dtype = dtype
+        if device is None:
+            device = get_best_device()
         self.device = device
 
         mean = [

--- a/wan/modules/vae2_2.py
+++ b/wan/modules/vae2_2.py
@@ -7,6 +7,8 @@ import torch.nn.functional as F
 from einops import rearrange
 from torch import autocast
 
+from ..utils.utils import get_best_device
+
 __all__ = [
     "Wan2_2_VAE",
 ]
@@ -903,10 +905,12 @@ class Wan2_2_VAE:
         dim_mult=[1, 2, 4, 4],
         temperal_downsample=[False, True, True],
         dtype=torch.float,
-        device="cuda",
+        device=None,
     ):
 
         self.dtype = dtype
+        if device is None:
+            device = get_best_device()
         self.device = device
 
         mean = torch.tensor(


### PR DESCRIPTION
## Summary
- add `get_best_device` helper to choose CUDA, MPS or CPU
- default VAE constructors to `device=None` and determine device with `get_best_device`
- ensure no modules pass `'cuda'` directly

## Testing
- `make format`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68abfd9c9508832084e7ba92655120e2