### PR TITLE
Automatically select available device in Wan2_2_VAE

### DIFF
--- a/wan/modules/vae2_2.py
+++ b/wan/modules/vae2_2.py
@@ -903,10 +903,19 @@ class Wan2_2_VAE:
         dim_mult=[1, 2, 4, 4],
         temperal_downsample=[False, True, True],
         dtype=torch.float,
-        device="cuda",
+        device=None,
     ):
 
         self.dtype = dtype
+        if device is None:
+            if torch.cuda.is_available():
+                device = torch.device("cuda")
+            elif torch.backends.mps.is_available():
+                device = torch.device("mps")
+            else:
+                device = torch.device("cpu")
+        else:
+            device = torch.device(device)
         self.device = device
 
         mean = torch.tensor(


### PR DESCRIPTION
## Summary
- Choose computation device for `Wan2_2_VAE` by checking CUDA and MPS availability

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68abfda773f083209eea9fb4c4bb3e46