### PR TITLE
Reuse backend-aware cache helper in image2video

### DIFF
--- a/wan/image2video.py
+++ b/wan/image2video.py
@@ -28,6 +28,7 @@ from .utils.fm_solvers import (
     retrieve_timesteps,
 )
 from .utils.fm_solvers_unipc import FlowUniPCMultistepScheduler
+from .utils.utils import torch_gc
 
 
 class WanI2V:
@@ -380,7 +381,7 @@ class WanI2V:
             }
 
             if offload_model:
-                torch.cuda.empty_cache()
+                torch_gc()
 
             for _, t in enumerate(tqdm(timesteps)):
                 latent_model_input = [latent.to(self.device)]
@@ -397,12 +398,12 @@ class WanI2V:
                                         t=timestep,
                                         **arg_c)[0]
                 if offload_model:
-                    torch.cuda.empty_cache()
+                    torch_gc()
                 noise_pred_uncond = model(latent_model_input,
                                           t=timestep,
                                           **arg_null)[0]
                 if offload_model:
-                    torch.cuda.empty_cache()
+                    torch_gc()
                 noise_pred = noise_pred_uncond + sample_guide_scale * (
                     noise_pred_cond - noise_pred_uncond)
 
@@ -419,7 +420,7 @@ class WanI2V:
             if offload_model:
                 self.low_noise_model.cpu()
                 self.high_noise_model.cpu()
-                torch.cuda.empty_cache()
+                torch_gc()
 
             if self.rank == 0:
                 videos = self.vae.decode(x0)
@@ -428,7 +429,7 @@ class WanI2V:
         del sample_scheduler
         if offload_model:
             gc.collect()
-            torch.cuda.synchronize()
+            torch_gc()
         if dist.is_initialized():
             dist.barrier()
 

--- a/wan/utils/utils.py
+++ b/wan/utils/utils.py
@@ -9,7 +9,7 @@ import imageio
 import torch
 import torchvision
 
-__all__ = ['save_video', 'save_image', 'str2bool']
+__all__ = ['save_video', 'save_image', 'str2bool', 'torch_gc']
 
 
 def rand_name(length=8, suffix=''):
@@ -101,6 +101,20 @@ def str2bool(v):
         return False
     else:
         raise argparse.ArgumentTypeError('Boolean value expected (True/False)')
+
+
+def torch_gc():
+    """
+    Release cached GPU memory and synchronize the device.
+
+    Uses CUDA when available otherwise falls back to Apple's MPS backend.
+    """
+    if torch.cuda.is_available():
+        torch.cuda.empty_cache()
+        torch.cuda.synchronize()
+    elif torch.backends.mps.is_available():
+        torch.mps.empty_cache()
+        torch.mps.synchronize()
 
 
 def masks_like(tensor, zero=False, generator=None, p=0.2):


### PR DESCRIPTION
## Summary
- Add `torch_gc` helper that clears GPU cache and synchronizes for CUDA or MPS
- Replace direct `torch.cuda.empty_cache()` and `torch.cuda.synchronize()` calls in `image2video.py` with `torch_gc`

## Testing
- `python -m py_compile wan/utils/utils.py wan/image2video.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68abfdac7fd48320b7765e741f3b1efd