### PR TITLE
feat: device-aware cache helpers

### DIFF
--- a/wan/textimage2video.py
+++ b/wan/textimage2video.py
@@ -28,7 +28,12 @@ from .utils.fm_solvers import (
     retrieve_timesteps,
 )
 from .utils.fm_solvers_unipc import FlowUniPCMultistepScheduler
-from .utils.utils import best_output_size, masks_like
+from .utils.utils import (
+    best_output_size,
+    masks_like,
+    device_empty_cache,
+    device_synchronize,
+)
 
 
 class WanTI2V:
@@ -365,7 +370,7 @@ class WanTI2V:
 
             if offload_model or self.init_on_cpu:
                 self.model.to(self.device)
-                torch.cuda.empty_cache()
+                device_empty_cache(self.device)
 
             for _, t in enumerate(tqdm(timesteps)):
                 latent_model_input = latents
@@ -399,8 +404,8 @@ class WanTI2V:
             x0 = latents
             if offload_model:
                 self.model.cpu()
-                torch.cuda.synchronize()
-                torch.cuda.empty_cache()
+                device_synchronize(self.device)
+                device_empty_cache(self.device)
             if self.rank == 0:
                 videos = self.vae.decode(x0)
 
@@ -408,7 +413,7 @@ class WanTI2V:
         del sample_scheduler
         if offload_model:
             gc.collect()
-            torch.cuda.synchronize()
+            device_synchronize(self.device)
         if dist.is_initialized():
             dist.barrier()
 
@@ -567,7 +572,7 @@ class WanTI2V:
 
             if offload_model or self.init_on_cpu:
                 self.model.to(self.device)
-                torch.cuda.empty_cache()
+                device_empty_cache(self.device)
 
             for _, t in enumerate(tqdm(timesteps)):
                 latent_model_input = [latent.to(self.device)]
@@ -586,12 +591,12 @@ class WanTI2V:
                                              t=timestep,
                                              **arg_c)[0]
                 if offload_model:
-                    torch.cuda.empty_cache()
+                    device_empty_cache(self.device)
                 noise_pred_uncond = self.model(latent_model_input,
                                                t=timestep,
                                                **arg_null)[0]
                 if offload_model:
-                    torch.cuda.empty_cache()
+                    device_empty_cache(self.device)
                 noise_pred = noise_pred_uncond + guide_scale * (
                     noise_pred_cond - noise_pred_uncond)
 
@@ -608,8 +613,8 @@ class WanTI2V:
 
             if offload_model:
                 self.model.cpu()
-                torch.cuda.synchronize()
-                torch.cuda.empty_cache()
+                device_synchronize(self.device)
+                device_empty_cache(self.device)
 
             if self.rank == 0:
                 videos = self.vae.decode(x0)
@@ -618,7 +623,7 @@ class WanTI2V:
         del sample_scheduler
         if offload_model:
             gc.collect()
-            torch.cuda.synchronize()
+            device_synchronize(self.device)
         if dist.is_initialized():
             dist.barrier()
 

--- a/wan/utils/utils.py
+++ b/wan/utils/utils.py
@@ -9,7 +9,13 @@ import imageio
 import torch
 import torchvision
 
-__all__ = ['save_video', 'save_image', 'str2bool']
+__all__ = [
+    'save_video',
+    'save_image',
+    'str2bool',
+    'device_empty_cache',
+    'device_synchronize',
+]
 
 
 def rand_name(length=8, suffix=''):
@@ -19,6 +25,30 @@ def rand_name(length=8, suffix=''):
             suffix = '.' + suffix
         name += suffix
     return name
+
+
+def device_empty_cache(device):
+    """Release unused cached memory for the specified device."""
+    if isinstance(device, torch.device):
+        device_type = device.type
+    else:
+        device_type = str(device)
+    if device_type == 'cuda':
+        torch.cuda.empty_cache()
+    elif device_type == 'mps':
+        torch.mps.empty_cache()
+
+
+def device_synchronize(device):
+    """Synchronize the specified device if supported."""
+    if isinstance(device, torch.device):
+        device_type = device.type
+    else:
+        device_type = str(device)
+    if device_type == 'cuda':
+        torch.cuda.synchronize()
+    elif device_type == 'mps':
+        torch.mps.synchronize()
 
 
 def save_video(tensor,


### PR DESCRIPTION
## Summary
- add helper utilities for device-aware cache and sync operations
- use device-aware helpers in textimage2video generation paths to support CUDA and MPS

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68abfdad9f788320a1040edf126b0c0c