### PR TITLE
feat: add device helper functions for cache and sync

### DIFF
--- a/generate.py
+++ b/generate.py
@@ -18,7 +18,7 @@ import wan
 from wan.configs import MAX_AREA_CONFIGS, SIZE_CONFIGS, SUPPORTED_SIZES, WAN_CONFIGS
 from wan.distributed.util import init_distributed_group
 from wan.utils.prompt_extend import DashScopePromptExpander, QwenPromptExpander
-from wan.utils.utils import save_video, str2bool
+from wan.utils.utils import device_synchronize, save_video, str2bool
 
 EXAMPLE_PROMPT = {
     "t2v-A14B": {
@@ -410,7 +410,7 @@ def generate(args):
             value_range=(-1, 1))
     del video
 
-    torch.cuda.synchronize()
+    device_synchronize()
     if dist.is_initialized():
         dist.barrier()
         dist.destroy_process_group()

--- a/wan/text2video.py
+++ b/wan/text2video.py
@@ -26,6 +26,7 @@ from .utils.fm_solvers import (
     retrieve_timesteps,
 )
 from .utils.fm_solvers_unipc import FlowUniPCMultistepScheduler
+from .utils.utils import device_empty_cache, device_synchronize
 
 
 class WanT2V:
@@ -369,7 +370,7 @@ class WanT2V:
             if offload_model:
                 self.low_noise_model.cpu()
                 self.high_noise_model.cpu()
-                torch.cuda.empty_cache()
+                device_empty_cache()
             if self.rank == 0:
                 videos = self.vae.decode(x0)
 
@@ -377,7 +378,7 @@ class WanT2V:
         del sample_scheduler
         if offload_model:
             gc.collect()
-            torch.cuda.synchronize()
+            device_synchronize()
         if dist.is_initialized():
             dist.barrier()
 

--- a/wan/utils/utils.py
+++ b/wan/utils/utils.py
@@ -9,7 +9,27 @@ import imageio
 import torch
 import torchvision
 
-__all__ = ['save_video', 'save_image', 'str2bool']
+__all__ = [
+    'save_video',
+    'save_image',
+    'str2bool',
+    'device_empty_cache',
+    'device_synchronize',
+]
+
+
+def device_empty_cache():
+    if torch.cuda.is_available():
+        torch.cuda.empty_cache()
+    elif torch.backends.mps.is_available():
+        torch.mps.empty_cache()
+
+
+def device_synchronize():
+    if torch.cuda.is_available():
+        torch.cuda.synchronize()
+    elif torch.backends.mps.is_available():
+        torch.mps.synchronize()
 
 
 def rand_name(length=8, suffix=''):


### PR DESCRIPTION
## Summary
- add `device_empty_cache` and `device_synchronize` helpers that support CUDA and MPS
- use new helpers in video generation utilities and CLI to avoid backend-specific calls

## Testing
- `python -m py_compile wan/utils/utils.py wan/image2video.py wan/text2video.py wan/textimage2video.py generate.py`
- `pytest -q`
- Attempted `python - <<'PY' ...` (failed: ModuleNotFoundError: No module named 'torch')
- `pip install torch==2.0.0 --extra-index-url https://download.pytorch.org/whl/cpu -q` (failed: No matching distribution found for torch==2.0.0)


------
https://chatgpt.com/codex/tasks/task_e_68abfdb1eae08320906d1c12425a91bd