### PR TITLE
feat: allow configurable temp dir for video cache

### DIFF
--- a/wan/utils/utils.py
+++ b/wan/utils/utils.py
@@ -4,6 +4,7 @@ import binascii
 import logging
 import os
 import os.path as osp
+import tempfile
 
 import imageio
 import torch
@@ -27,10 +28,34 @@ def save_video(tensor,
                suffix='.mp4',
                nrow=8,
                normalize=True,
-               value_range=(-1, 1)):
+               value_range=(-1, 1),
+               tmp_dir=None):
+    """Save a 5D tensor as a video file.
+
+    Args:
+        tensor (torch.Tensor): Video tensor of shape (B, C, T, H, W).
+        save_file (str, optional): Path to save the video. If ``None`` a
+            temporary file will be created.
+        fps (int, optional): Frames per second. Defaults to ``30``.
+        suffix (str, optional): Suffix for temporary files. Defaults to ``'.mp4'``.
+        nrow (int, optional): Number of images per row. Defaults to ``8``.
+        normalize (bool, optional): Whether to normalize the tensor. Defaults to
+            ``True``.
+        value_range (tuple, optional): Value range for normalization. Defaults to
+            ``(-1, 1)``.
+        tmp_dir (str, optional): Directory used for temporary files when
+            ``save_file`` is ``None``. Defaults to ``None`` which uses
+            :func:`tempfile.gettempdir`.
+
+    Returns:
+        None
+    """
     # cache file
-    cache_file = osp.join('/tmp', rand_name(
-        suffix=suffix)) if save_file is None else save_file
+    if save_file is None:
+        tmp_dir = tempfile.gettempdir() if tmp_dir is None else tmp_dir
+        cache_file = osp.join(tmp_dir, rand_name(suffix=suffix))
+    else:
+        cache_file = save_file
 
     # save to cache
     try:


### PR DESCRIPTION
## Summary
- let `save_video` create temporary files via `tempfile.gettempdir`
- add `tmp_dir` argument to override temp location and document function

## Testing
- `python -m py_compile wan/utils/utils.py`
- `pytest -q` *(no tests discovered)*
- Ran manual call to `save_video` to check temp file creation *(no files produced; environment may lack video codec)*

------
https://chatgpt.com/codex/tasks/task_e_68abfdb2f9948320a7c3c7a49604baf6