### PR TITLE
refactor: reuse shared device sync

### DIFF
--- a/generate.py
+++ b/generate.py
@@ -22,13 +22,6 @@ from wan.utils.utils import save_video, str2bool
 from wan.utils.device import synchronize_device
 
 
-def synchronize_device():
-    if torch.cuda.is_available():
-        torch.cuda.synchronize()
-    elif torch.backends.mps.is_available():
-        torch.mps.synchronize()
-
-
 EXAMPLE_PROMPT = {
     "t2v-A14B": {
         "prompt":


### PR DESCRIPTION
## Summary
- remove duplicate `synchronize_device` from `generate.py`
- rely on shared `wan.utils.device.synchronize_device`

## Testing
- `python - <<'PY'
import types, sys, runpy
# Stub torch
...
import generate
print('Imported generate')
print(generate.synchronize_device)
generate.synchronize_device()
print('done')
PY`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac0242a3f08320aa6c07c8c2ea4f72