### PR TITLE
docs: add macOS-specific dependencies

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -35,27 +35,17 @@ Use [Homebrew](https://brew.sh) to install `ffmpeg` for video generation:
 brew install ffmpeg
 ```
 
-### `flash-attn`
+### Install project dependencies
 
-`flash-attn` is not supported on macOS. Skip its installation or replace it with another attention implementation such as [`xformers`](https://github.com/facebookresearch/xformers).
+After installing PyTorch, install the remaining dependencies. The requirements
+file installs `xformers` and automatically skips `flash-attn` on macOS:
 
-### Handling `flash-attn` Installation Issues
-
-macOS users can skip installing `flash_attn`.
-
-If `flash-attn` fails due to **PEP 517 build issues**, you can try one of the following fixes.
-
-#### No-Build-Isolation Installation (Recommended)
 ```bash
-poetry run pip install --upgrade pip setuptools wheel
-poetry run pip install flash-attn --no-build-isolation
-poetry install
+pip install -r requirements.txt
 ```
 
-#### Install from Git (Alternative)
-```bash
-poetry run pip install git+https://github.com/Dao-AILab/flash-attention.git
-```
+`flash-attn` is currently unsupported on macOS, but `xformers` provides similar
+attention optimizations for Apple hardware.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -76,8 +76,6 @@ cd Wan2.2
 Install dependencies:
 ```sh
 # Ensure torch >= 2.4.0
-# macOS users can skip installing `flash_attn`
-# If the installation of `flash_attn` fails, try installing the other packages first and install `flash_attn` last
 pip install -r requirements.txt
 ```
 
@@ -90,14 +88,13 @@ brew install ffmpeg
 # Install PyTorch with MPS acceleration
 pip3 install torch==2.4.0 torchvision==0.19.0 torchaudio==2.4.0
 
-# Install remaining dependencies without flash_attn
-pip install $(grep -v 'flash_attn' requirements.txt | xargs)
-```
+# Install project dependencies (installs xformers, skips flash_attn automatically)
+pip install -r requirements.txt
 
 # Verify that PyTorch detects the MPS backend
 python -c "import torch; print(torch.backends.mps.is_available())"
-
-> FlashAttention is currently unsupported on Apple's MPS backend, so installing `flash_attn` is unnecessary.
+```
+> FlashAttention is currently unsupported on Apple's MPS backend, so `flash_attn` is skipped and `xformers` is installed instead.
 
 Set the following environment variable to enable CPU fallback for operations not yet
 implemented by Apple's MPS backend:

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,4 +12,5 @@ ftfy
 dashscope
 imageio-ffmpeg
 flash_attn; platform_system != "Darwin"
+xformers; platform_system == "Darwin"
 numpy>=1.23.5,<2


### PR DESCRIPTION
## Summary
- install xformers only on macOS via environment markers
- document Homebrew ffmpeg and macOS-specific dependency steps

## Testing
- `pip install --dry-run -r requirements.txt --platform macosx_13_0_arm64 --implementation cp --python-version 3.10 --abi cp310 --only-binary=:all:` (fails: No matching distribution found for flash_attn)
- `python - <<'PY'
from packaging.requirements import Requirement
req1 = Requirement('flash_attn; platform_system != "Darwin"')
req2 = Requirement('xformers; platform_system == "Darwin"')
print('flash_attn on Darwin:', req1.marker.evaluate({'platform_system':'Darwin'}))
print('xformers on Darwin:', req2.marker.evaluate({'platform_system':'Darwin'}))
PY`
- `bash tests/test.sh dummy 1` (fails: torchrun: command not found)

------
https://chatgpt.com/codex/tasks/task_e_68ac0245a99c8320a65263f223fe47e3