### PR TITLE
refactor: centralize MPS float32 conversion

### DIFF
--- a/wan/utils/__init__.py
+++ b/wan/utils/__init__.py
@@ -5,8 +5,10 @@ from .fm_solvers import (
     retrieve_timesteps,
 )
 from .fm_solvers_unipc import FlowUniPCMultistepScheduler
+from .mps import ensure_float32
 
 __all__ = [
     'HuggingfaceTokenizer', 'get_sampling_sigmas', 'retrieve_timesteps',
-    'FlowDPMSolverMultistepScheduler', 'FlowUniPCMultistepScheduler'
+    'FlowDPMSolverMultistepScheduler', 'FlowUniPCMultistepScheduler',
+    'ensure_float32'
 ]

--- a/wan/utils/fm_solvers.py
+++ b/wan/utils/fm_solvers.py
@@ -17,6 +17,8 @@ from diffusers.schedulers.scheduling_utils import (
 from diffusers.utils import deprecate, is_scipy_available
 from diffusers.utils.torch_utils import randn_tensor
 
+from .mps import ensure_float32
+
 if is_scipy_available():
     pass
 
@@ -823,16 +825,9 @@ class FlowDPMSolverMultistepScheduler(SchedulerMixin, ConfigMixin):
         # Make sure sigmas and timesteps have the same device and dtype as original_samples
         sigmas = self.sigmas.to(
             device=original_samples.device, dtype=original_samples.dtype)
-        if original_samples.device.type == "mps" and torch.is_floating_point(
-                timesteps):
-            # mps does not support float64
-            schedule_timesteps = self.timesteps.to(
-                original_samples.device, dtype=torch.float32)
-            timesteps = timesteps.to(
-                original_samples.device, dtype=torch.float32)
-        else:
-            schedule_timesteps = self.timesteps.to(original_samples.device)
-            timesteps = timesteps.to(original_samples.device)
+        schedule_timesteps = ensure_float32(
+            self.timesteps.to(original_samples.device))
+        timesteps = ensure_float32(timesteps.to(original_samples.device))
 
         # begin_index is None when the scheduler is used for training or pipeline does not implement set_begin_index
         if self.begin_index is None:

--- a/wan/utils/mps.py
+++ b/wan/utils/mps.py
@@ -1,0 +1,24 @@
+import torch
+
+
+def ensure_float32(tensor: torch.Tensor) -> torch.Tensor:
+    """Ensure ``tensor`` is ``float32`` on MPS devices.
+
+    MPS backend does not support ``float64`` tensors. This helper converts
+    ``float64`` tensors to ``float32`` when the tensor resides on an MPS
+    device. Tensors on other backends or with different dtypes are returned
+    unchanged.
+
+    Parameters
+    ----------
+    tensor: torch.Tensor
+        The input tensor to check.
+
+    Returns
+    -------
+    torch.Tensor
+        The converted tensor if necessary, otherwise the original tensor.
+    """
+    if isinstance(tensor, torch.Tensor) and tensor.device.type == "mps" and tensor.dtype == torch.float64:
+        return tensor.float()
+    return tensor


### PR DESCRIPTION
## Summary
- add `ensure_float32` helper to convert float64 tensors on MPS to float32
- use helper in flow matching solvers to avoid manual dtype checks
- expose utility in `wan.utils`

## Testing
- `pytest`
- `python -m py_compile wan/utils/mps.py wan/utils/fm_solvers.py wan/utils/fm_solvers_unipc.py wan/utils/__init__.py`


------
https://chatgpt.com/codex/tasks/task_e_68ac0246dca883209a1bcce4e366a368