### PR TITLE
Remove redundant synchronize_device definition

### DIFF
--- a/generate.py
+++ b/generate.py
@@ -22,13 +22,6 @@ from wan.utils.utils import save_video, str2bool
 from wan.utils.device import synchronize_device
 
 
-def synchronize_device():
-    if torch.cuda.is_available():
-        torch.cuda.synchronize()
-    elif torch.backends.mps.is_available():
-        torch.mps.synchronize()
-
-
 EXAMPLE_PROMPT = {
     "t2v-A14B": {
         "prompt":


### PR DESCRIPTION
## Summary
- remove local synchronize_device() from generate.py and rely on util implementation

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ac024b8e608320ac55ed95db38dd6c