### PR TITLE
feat: support mps float16

### DIFF
--- a/wan/configs/shared_config.py
+++ b/wan/configs/shared_config.py
@@ -11,7 +11,10 @@ wan_shared_cfg.t5_dtype = torch.bfloat16
 wan_shared_cfg.text_len = 512
 
 # transformer
-wan_shared_cfg.param_dtype = torch.bfloat16
+# Use float16 when running on Apple Silicon (MPS) where bfloat16
+# is not supported. Otherwise keep the original bfloat16 dtype.
+wan_shared_cfg.param_dtype = (torch.float16 if torch.backends.mps.is_available()
+                              else torch.bfloat16)
 
 # inference
 wan_shared_cfg.num_train_timesteps = 1000


### PR DESCRIPTION
## Summary
- configure `param_dtype` to use `float16` when running on Apple MPS

## Testing
- `python -m py_compile wan/configs/shared_config.py wan/text2video.py wan/image2video.py wan/textimage2video.py wan/modules/t5.py`
- `bash tests/test.sh /tmp 1` *(fails: torchrun: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac024a22948320b15c0e6637f57e8c