### PR TITLE
feat: add unified device helper

### DIFF
--- a/wan/distributed/util.py
+++ b/wan/distributed/util.py
@@ -3,6 +3,8 @@ import os
 import torch
 import torch.distributed as dist
 
+from ..utils.device import get_best_device
+
 
 def init_distributed_group(backend: str | None = None):
     """Initialize sequence parallel group.
@@ -12,9 +14,10 @@ def init_distributed_group(backend: str | None = None):
     available, otherwise ``'gloo'``.
     """
     if backend is None:
+        device = get_best_device()
         backend = (
             os.getenv("WAN_BACKEND")
-            or ("nccl" if torch.cuda.is_available() else "gloo")
+            or ("nccl" if device.type == "cuda" else "gloo")
         )
     if not dist.is_initialized():
         dist.init_process_group(backend=backend)

--- a/wan/image2video.py
+++ b/wan/image2video.py
@@ -28,7 +28,7 @@ from .utils.fm_solvers import (
     retrieve_timesteps,
 )
 from .utils.fm_solvers_unipc import FlowUniPCMultistepScheduler
-from .utils.device import empty_device_cache, synchronize_device
+from .utils.device import empty_device_cache, get_best_device, synchronize_device
 
 
 class WanI2V:
@@ -72,12 +72,7 @@ class WanI2V:
                 Convert DiT model parameters dtype to 'config.param_dtype'.
                 Only works without FSDP.
         """
-        if torch.cuda.is_available():
-            self.device = torch.device(f"cuda:{device_id}")
-        elif torch.backends.mps.is_available():
-            self.device = torch.device("mps")
-        else:
-            self.device = torch.device("cpu")
+        self.device = get_best_device(device_id)
         self.config = config
         self.rank = rank
         self.t5_cpu = t5_cpu

--- a/wan/modules/t5.py
+++ b/wan/modules/t5.py
@@ -8,6 +8,7 @@ import torch.nn as nn
 import torch.nn.functional as F
 
 from .tokenizers import HuggingfaceTokenizer
+from ..utils.device import get_best_device
 
 __all__ = [
     'T5Model',
@@ -481,12 +482,7 @@ class T5EncoderModel:
         shard_fn=None,
     ):
         if device is None:
-            if torch.cuda.is_available():
-                device = torch.device(f"cuda:{torch.cuda.current_device()}")
-            elif torch.backends.mps.is_available():
-                device = torch.device("mps")
-            else:
-                device = torch.device("cpu")
+            device = get_best_device()
         self.text_len = text_len
         self.dtype = dtype
         self.device = device

--- a/wan/text2video.py
+++ b/wan/text2video.py
@@ -26,7 +26,7 @@ from .utils.fm_solvers import (
     retrieve_timesteps,
 )
 from .utils.fm_solvers_unipc import FlowUniPCMultistepScheduler
-from .utils.device import empty_device_cache, synchronize_device
+from .utils.device import empty_device_cache, get_best_device, synchronize_device
 
 
 class WanT2V:
@@ -70,12 +70,7 @@ class WanT2V:
                 Convert DiT model parameters dtype to 'config.param_dtype'.
                 Only works without FSDP.
         """
-        if torch.cuda.is_available():
-            self.device = torch.device(f"cuda:{device_id}")
-        elif torch.backends.mps.is_available():
-            self.device = torch.device("mps")
-        else:
-            self.device = torch.device("cpu")
+        self.device = get_best_device(device_id)
         self.config = config
         self.rank = rank
         self.t5_cpu = t5_cpu

--- a/wan/textimage2video.py
+++ b/wan/textimage2video.py
@@ -29,7 +29,7 @@ from .utils.fm_solvers import (
 )
 from .utils.fm_solvers_unipc import FlowUniPCMultistepScheduler
 from .utils.utils import best_output_size, masks_like
-from .utils.device import empty_device_cache, synchronize_device
+from .utils.device import empty_device_cache, get_best_device, synchronize_device
 
 
 class WanTI2V:
@@ -73,12 +73,7 @@ class WanTI2V:
                 Convert DiT model parameters dtype to 'config.param_dtype'.
                 Only works without FSDP.
         """
-        if torch.cuda.is_available():
-            self.device = torch.device(f"cuda:{device_id}")
-        elif torch.backends.mps.is_available():
-            self.device = torch.device("mps")
-        else:
-            self.device = torch.device("cpu")
+        self.device = get_best_device(device_id)
         self.config = config
         self.rank = rank
         self.t5_cpu = t5_cpu

--- a/wan/utils/utils.py
+++ b/wan/utils/utils.py
@@ -10,19 +10,9 @@ import imageio
 import torch
 import torchvision
 
+from .device import get_best_device
+
 __all__ = ['save_video', 'save_image', 'str2bool', 'get_best_device']
-
-
-def get_best_device():
-    """Return the best available torch device.
-
-    Preference order is CUDA, then MPS (Apple Silicon), and finally CPU.
-    """
-    if torch.cuda.is_available():
-        return torch.device("cuda")
-    if torch.backends.mps.is_available():
-        return torch.device("mps")
-    return torch.device("cpu")
 
 
 def rand_name(length=8, suffix=''):


### PR DESCRIPTION
## Summary
- allow selecting GPU by index via new `get_best_device`
- replace scattered CUDA checks with common helper
- use helper in distributed util and generation scripts

## Testing
- `bash tests/test.sh >/tmp/test.log && tail -n 20 /tmp/test.log` *(fails: missing arguments)*
- `python -m py_compile generate.py wan/distributed/util.py wan/image2video.py wan/modules/t5.py wan/text2video.py wan/textimage2video.py wan/utils/device.py wan/utils/utils.py`
- `python - <<'PY'
import os, torch, importlib.util
spec = importlib.util.spec_from_file_location('device', 'wan/utils/device.py')
mod = importlib.util.module_from_spec(spec)
spec.loader.exec_module(mod)
get_best_device = mod.get_best_device
os.environ['LOCAL_RANK']='1'
orig = torch.cuda.is_available
try:
    torch.cuda.is_available=lambda: True
    d1 = get_best_device()
    d2 = get_best_device(0)
    print('auto device:', d1)
    print('explicit device:', d2)
finally:
    torch.cuda.is_available = orig
    os.environ.pop('LOCAL_RANK', None)
PY`

------
https://chatgpt.com/codex/tasks/task_e_68ac024c6398832090e8f1e0261417a5