### PR TITLE
Support MPS for model offloading

### DIFF
--- a/wan/image2video.py
+++ b/wan/image2video.py
@@ -201,7 +201,8 @@ class WanI2V:
         if offload_model or self.init_on_cpu:
             if next(getattr(
                     self,
-                    offload_model_name).parameters()).device.type == 'cuda':
+                    offload_model_name).parameters()).device.type in ('cuda', 'mps'):
+                # Offload unused model from GPU/MPS to CPU to free memory
                 getattr(self, offload_model_name).to('cpu')
             if next(getattr(
                     self,

--- a/wan/text2video.py
+++ b/wan/text2video.py
@@ -198,7 +198,8 @@ class WanT2V:
         if offload_model or self.init_on_cpu:
             if next(getattr(
                     self,
-                    offload_model_name).parameters()).device.type == 'cuda':
+                    offload_model_name).parameters()).device.type in ('cuda', 'mps'):
+                # Offload unused model from GPU/MPS to CPU to free memory
                 getattr(self, offload_model_name).to('cpu')
             if next(getattr(
                     self,


### PR DESCRIPTION
## Summary
- allow `_prepare_model_for_timestep` to offload models on CUDA or MPS devices to CPU
- clarify comment about GPU/MPS offloading

## Testing
- `python -m py_compile wan/image2video.py wan/text2video.py`
- `pytest -q`
- `python - <<'PY'
import torch
print('Torch version:', torch.__version__)
print('MPS available:', torch.backends.mps.is_available())
PY`


------
https://chatgpt.com/codex/tasks/task_e_68ac025105b4832085e434e992b64820