### PR TITLE
Use float16 parameters on MPS and pass dtype to FSDP

### DIFF
--- a/wan/configs/shared_config.py
+++ b/wan/configs/shared_config.py
@@ -11,7 +11,10 @@ wan_shared_cfg.t5_dtype = torch.bfloat16
 wan_shared_cfg.text_len = 512
 
 # transformer
-wan_shared_cfg.param_dtype = torch.bfloat16
+if torch.backends.mps.is_available():
+    wan_shared_cfg.param_dtype = torch.float16
+else:
+    wan_shared_cfg.param_dtype = torch.bfloat16
 
 # inference
 wan_shared_cfg.num_train_timesteps = 1000

--- a/wan/image2video.py
+++ b/wan/image2video.py
@@ -90,7 +90,8 @@ class WanI2V:
         if t5_fsdp or dit_fsdp or use_sp:
             self.init_on_cpu = False
 
-        shard_fn = partial(shard_model, device_id=device_id)
+        shard_fn = partial(shard_model, device_id=device_id,
+                           param_dtype=self.param_dtype)
         self.text_encoder = T5EncoderModel(
             text_len=config.text_len,
             dtype=config.t5_dtype,

--- a/wan/text2video.py
+++ b/wan/text2video.py
@@ -88,7 +88,8 @@ class WanT2V:
         if t5_fsdp or dit_fsdp or use_sp:
             self.init_on_cpu = False
 
-        shard_fn = partial(shard_model, device_id=device_id)
+        shard_fn = partial(shard_model, device_id=device_id,
+                           param_dtype=self.param_dtype)
         self.text_encoder = T5EncoderModel(
             text_len=config.text_len,
             dtype=config.t5_dtype,

--- a/wan/textimage2video.py
+++ b/wan/textimage2video.py
@@ -90,7 +90,8 @@ class WanTI2V:
         if t5_fsdp or dit_fsdp or use_sp:
             self.init_on_cpu = False
 
-        shard_fn = partial(shard_model, device_id=device_id)
+        shard_fn = partial(shard_model, device_id=device_id,
+                           param_dtype=self.param_dtype)
         self.text_encoder = T5EncoderModel(
             text_len=config.text_len,
             dtype=config.t5_dtype,


### PR DESCRIPTION
## Summary
- set `param_dtype` to `torch.float16` when MPS is available
- propagate `config.param_dtype` into FSDP sharding in generation scripts

## Testing
- `python -m py_compile wan/configs/shared_config.py wan/text2video.py wan/image2video.py wan/textimage2video.py`
- `pytest`
- `python - <<'PY'
import importlib.util, torch

def load():
    spec = importlib.util.spec_from_file_location('shared_config', 'wan/configs/shared_config.py')
    mod = importlib.util.module_from_spec(spec)
    spec.loader.exec_module(mod)
    return mod

sc = load()
print('MPS available default:', torch.backends.mps.is_available())
print('param_dtype default:', sc.wan_shared_cfg.param_dtype)

torch.backends.mps.is_available = lambda: True
sc_mps = load()
print('param_dtype when MPS:', sc_mps.wan_shared_cfg.param_dtype)
PY`

------
https://chatgpt.com/codex/tasks/task_e_68ac0251c3d08320bdb48cba5c84838e