### PR TITLE
Add optional xformers dependency for macOS

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = [
     "dashscope",
     "imageio-ffmpeg",
     "flash_attn; platform_system != \"Darwin\"",
+    "xformers; platform_system == \"Darwin\"",
     "numpy>=1.23.5,<2"
 ]
 


### PR DESCRIPTION
## Summary
- include xformers as a Darwin-only dependency

## Testing
- `poetry lock`


------
https://chatgpt.com/codex/tasks/task_e_68ac18538e548320a929ee212b032d28