### PR TITLE
Use torch.inference_mode in generation loops

### DIFF
--- a/wan/image2video.py
+++ b/wan/image2video.py
@@ -339,7 +339,7 @@ class WanI2V:
         # evaluation mode
         with (
                 autocast(device_type=self.device.type, dtype=self.param_dtype),
-                torch.no_grad(),
+                torch.inference_mode(),
                 no_sync_low_noise(),
                 no_sync_high_noise(),
         ):

--- a/wan/text2video.py
+++ b/wan/text2video.py
@@ -306,7 +306,7 @@ class WanT2V:
         # evaluation mode
         with (
                 autocast(device_type=self.device.type, dtype=self.param_dtype),
-                torch.no_grad(),
+                torch.inference_mode(),
                 no_sync_low_noise(),
                 no_sync_high_noise(),
         ):

--- a/wan/textimage2video.py
+++ b/wan/textimage2video.py
@@ -332,7 +332,7 @@ class WanTI2V:
         # evaluation mode
         with (
                 autocast(device_type=self.device.type, dtype=self.param_dtype),
-                torch.no_grad(),
+                torch.inference_mode(),
                 no_sync(),
         ):
 
@@ -526,7 +526,7 @@ class WanTI2V:
         # evaluation mode
         with (
                 autocast(device_type=self.device.type, dtype=self.param_dtype),
-                torch.no_grad(),
+                torch.inference_mode(),
                 no_sync(),
         ):
 


### PR DESCRIPTION
## Summary
- Replace `torch.no_grad()` with `torch.inference_mode()` in text-, image-, and text+image-to-video pipelines.
- Audited generation loops to ensure no unsafe in-place operations under `inference_mode`.

## Testing
- `python -m py_compile wan/text2video.py wan/image2video.py wan/textimage2video.py`
- `pytest` (no tests ran)


------
https://chatgpt.com/codex/tasks/task_e_68ac1922a50c8320a89b81d6db2a894d