### PR TITLE
free device cache after offloading

### DIFF
--- a/wan/image2video.py
+++ b/wan/image2video.py
@@ -204,6 +204,7 @@ class WanI2V:
                     offload_model_name).parameters()).device.type in ('cuda', 'mps'):
                 # Offload unused model from GPU/MPS to CPU to free memory
                 getattr(self, offload_model_name).to('cpu')
+                empty_device_cache()
             if next(getattr(
                     self,
                     required_model_name).parameters()).device.type == 'cpu':
@@ -310,6 +311,7 @@ class WanI2V:
             context_null = self.text_encoder([n_prompt], self.device)
             if offload_model:
                 self.text_encoder.model.cpu()
+                empty_device_cache()
         else:
             context = self.text_encoder([input_prompt], torch.device('cpu'))
             context_null = self.text_encoder([n_prompt], torch.device('cpu'))

--- a/wan/text2video.py
+++ b/wan/text2video.py
@@ -201,6 +201,7 @@ class WanT2V:
                     offload_model_name).parameters()).device.type in ('cuda', 'mps'):
                 # Offload unused model from GPU/MPS to CPU to free memory
                 getattr(self, offload_model_name).to('cpu')
+                empty_device_cache()
             if next(getattr(
                     self,
                     required_model_name).parameters()).device.type == 'cpu':
@@ -278,6 +279,7 @@ class WanT2V:
             context_null = self.text_encoder([n_prompt], self.device)
             if offload_model:
                 self.text_encoder.model.cpu()
+                empty_device_cache()
         else:
             context = self.text_encoder([input_prompt], torch.device('cpu'))
             context_null = self.text_encoder([n_prompt], torch.device('cpu'))

--- a/wan/textimage2video.py
+++ b/wan/textimage2video.py
@@ -307,6 +307,7 @@ class WanTI2V:
             context_null = self.text_encoder([n_prompt], self.device)
             if offload_model:
                 self.text_encoder.model.cpu()
+                empty_device_cache()
         else:
             context = self.text_encoder([input_prompt], torch.device('cpu'))
             context_null = self.text_encoder([n_prompt], torch.device('cpu'))
@@ -509,6 +510,7 @@ class WanTI2V:
             context_null = self.text_encoder([n_prompt], self.device)
             if offload_model:
                 self.text_encoder.model.cpu()
+                empty_device_cache()
         else:
             context = self.text_encoder([input_prompt], torch.device('cpu'))
             context_null = self.text_encoder([n_prompt], torch.device('cpu'))


### PR DESCRIPTION
## Summary
- free device cache after transferring models to CPU across video pipelines
- clean up text encoder offloading by flushing device cache

## Testing
- `pytest`
- `python -m py_compile wan/text2video.py wan/image2video.py wan/textimage2video.py`


------
https://chatgpt.com/codex/tasks/task_e_68ac19233700832096eb4122959f203c