### PR TITLE
Support configurable dtype and T5 encoder casting

### DIFF
--- a/wan/configs/shared_config.py
+++ b/wan/configs/shared_config.py
@@ -5,16 +5,21 @@ from easydict import EasyDict
 #------------------------ Wan shared config ------------------------#
 wan_shared_cfg = EasyDict()
 
+# dtype
+# Users can modify this option in configuration files to switch
+# the precision of all model parameters. Half precision (float16)
+# inference is supported when FSDP is disabled.
+wan_shared_cfg.dtype = (torch.float16
+                        if torch.backends.mps.is_available()
+                        else torch.bfloat16)
+
 # t5
 wan_shared_cfg.t5_model = 'umt5_xxl'
-wan_shared_cfg.t5_dtype = torch.bfloat16
+wan_shared_cfg.t5_dtype = wan_shared_cfg.dtype
 wan_shared_cfg.text_len = 512
 
 # transformer
-# Use float16 when running on Apple Silicon (MPS) where bfloat16
-# is not supported. Otherwise keep the original bfloat16 dtype.
-wan_shared_cfg.param_dtype = (torch.float16 if torch.backends.mps.is_available()
-                              else torch.bfloat16)
+wan_shared_cfg.param_dtype = wan_shared_cfg.dtype
 
 # inference
 wan_shared_cfg.num_train_timesteps = 1000

--- a/wan/image2video.py
+++ b/wan/image2video.py
@@ -99,6 +99,8 @@ class WanI2V:
             tokenizer_path=os.path.join(checkpoint_dir, config.t5_tokenizer),
             shard_fn=shard_fn if t5_fsdp else None,
         )
+        if not t5_fsdp:
+            self.text_encoder.model.to(self.param_dtype)
 
         self.vae_stride = config.vae_stride
         self.patch_size = config.patch_size

--- a/wan/text2video.py
+++ b/wan/text2video.py
@@ -96,6 +96,8 @@ class WanT2V:
             checkpoint_path=os.path.join(checkpoint_dir, config.t5_checkpoint),
             tokenizer_path=os.path.join(checkpoint_dir, config.t5_tokenizer),
             shard_fn=shard_fn if t5_fsdp else None)
+        if not t5_fsdp:
+            self.text_encoder.model.to(self.param_dtype)
 
         self.vae_stride = config.vae_stride
         self.patch_size = config.patch_size

--- a/wan/textimage2video.py
+++ b/wan/textimage2video.py
@@ -98,6 +98,8 @@ class WanTI2V:
             checkpoint_path=os.path.join(checkpoint_dir, config.t5_checkpoint),
             tokenizer_path=os.path.join(checkpoint_dir, config.t5_tokenizer),
             shard_fn=shard_fn if t5_fsdp else None)
+        if not t5_fsdp:
+            self.text_encoder.model.to(self.param_dtype)
 
         self.vae_stride = config.vae_stride
         self.patch_size = config.patch_size


### PR DESCRIPTION
## Summary
- allow model dtype to be switched via config
- cast T5 encoder to selected dtype when FSDP is disabled

## Testing
- `python -m py_compile wan/configs/shared_config.py wan/text2video.py wan/image2video.py wan/textimage2video.py`
- `bash tests/test.sh /tmp 1` *(fails: torchrun: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac192494b48320a578ffa6e53cd159