### PR TITLE
Free cache after offloading text2video models

### DIFF
--- a/wan/text2video.py
+++ b/wan/text2video.py
@@ -201,6 +201,7 @@ class WanT2V:
                     offload_model_name).parameters()).device.type in ('cuda', 'mps'):
                 # Offload unused model from GPU/MPS to CPU to free memory
                 getattr(self, offload_model_name).to('cpu')
+                empty_device_cache()
             if next(getattr(
                     self,
                     required_model_name).parameters()).device.type == 'cpu':


### PR DESCRIPTION
## Summary
- release device cache right after offloading the unused diffusion model in `_prepare_model_for_timestep`

## Testing
- `python -m py_compile wan/text2video.py`
- Attempted to simulate frequent offload to detect unwanted synchronization, but missing torch prevented runtime verification

------
https://chatgpt.com/codex/tasks/task_e_68ac192c37b08320a61eee973101caa1