### PR TITLE
Switch to torch.inference_mode for video generation inference

### DIFF
--- a/wan/image2video.py
+++ b/wan/image2video.py
@@ -339,7 +339,7 @@ class WanI2V:
         # evaluation mode
         with (
                 autocast(device_type=self.device.type, dtype=self.param_dtype),
-                torch.no_grad(),
+                torch.inference_mode(),
                 no_sync_low_noise(),
                 no_sync_high_noise(),
         ):

--- a/wan/text2video.py
+++ b/wan/text2video.py
@@ -306,7 +306,7 @@ class WanT2V:
         # evaluation mode
         with (
                 autocast(device_type=self.device.type, dtype=self.param_dtype),
-                torch.no_grad(),
+                torch.inference_mode(),
                 no_sync_low_noise(),
                 no_sync_high_noise(),
         ):

--- a/wan/textimage2video.py
+++ b/wan/textimage2video.py
@@ -332,7 +332,7 @@ class WanTI2V:
         # evaluation mode
         with (
                 autocast(device_type=self.device.type, dtype=self.param_dtype),
-                torch.no_grad(),
+                torch.inference_mode(),
                 no_sync(),
         ):
 
@@ -526,7 +526,7 @@ class WanTI2V:
         # evaluation mode
         with (
                 autocast(device_type=self.device.type, dtype=self.param_dtype),
-                torch.no_grad(),
+                torch.inference_mode(),
                 no_sync(),
         ):
 


### PR DESCRIPTION
## Summary
- replace deprecated `torch.no_grad()` with `torch.inference_mode()` in text-to-video, text-image-to-video, and image-to-video inference paths

## Testing
- `bash tests/test.sh /tmp/dummymodels 1` *(fails: ModuleNotFoundError: No module named 'easydict')*
- `python - <<'PY'
import torch
import torch.nn as nn
model = nn.Linear(10,5)
model.eval()
inp = torch.randn(1,10)
with torch.no_grad():
    out1 = model(inp)
with torch.inference_mode():
    out2 = model(inp)
print(torch.allclose(out1, out2))
PY`


------
https://chatgpt.com/codex/tasks/task_e_68ac19434780832088441a5623deba72