### PR TITLE
Use model dtype for noise generation

### DIFF
--- a/wan/image2video.py
+++ b/wan/image2video.py
@@ -287,7 +287,7 @@ class WanI2V:
         noise = torch.randn(16, (F - 1) // self.vae_stride[0] + 1,
                             lat_h,
                             lat_w,
-                            dtype=torch.float32,
+                            dtype=self.param_dtype,
                             generator=seed_g,
                             device=self.device)
 

--- a/wan/text2video.py
+++ b/wan/text2video.py
@@ -289,7 +289,7 @@ class WanT2V:
                         target_shape[1],
                         target_shape[2],
                         target_shape[3],
-                        dtype=torch.float32,
+                        dtype=self.param_dtype,
                         device=self.device,
                         generator=seed_g)
         ]

--- a/wan/textimage2video.py
+++ b/wan/textimage2video.py
@@ -318,7 +318,7 @@ class WanTI2V:
                         target_shape[1],
                         target_shape[2],
                         target_shape[3],
-                        dtype=torch.float32,
+                        dtype=self.param_dtype,
                         device=self.device,
                         generator=seed_g)
         ]
@@ -495,7 +495,7 @@ class WanTI2V:
                             (F - 1) // self.vae_stride[0] + 1,
                             oh // self.vae_stride[1],
                             ow // self.vae_stride[2],
-                            dtype=torch.float32,
+                            dtype=self.param_dtype,
                             generator=seed_g,
                             device=self.device)
 


### PR DESCRIPTION
## Summary
- use `self.param_dtype` instead of hardcoded `torch.float32` when creating noise tensors in text2video, textimage2video, and image2video

## Testing
- `python -m py_compile wan/text2video.py wan/textimage2video.py wan/image2video.py`
- `python generate.py --task t2v-A14B --ckpt_dir dummy --size 480*832` *(fails: process killed due to missing resources)*

------
https://chatgpt.com/codex/tasks/task_e_68ac1948ac88832082d93abfa7c50cf6