### PR TITLE
Use inference_mode for T5 encoder

### DIFF
--- a/wan/modules/t5.py
+++ b/wan/modules/t5.py
@@ -516,5 +516,6 @@ class T5EncoderModel:
         ids = ids.to(device)
         mask = mask.to(device)
         seq_lens = mask.gt(0).sum(dim=1).long()
-        context = self.model(ids, mask)
+        with torch.inference_mode():
+            context = self.model(ids, mask)
         return [u[:v] for u, v in zip(context, seq_lens)]


### PR DESCRIPTION
## Summary
- wrap T5EncoderModel forward call in `torch.inference_mode`

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ac22f039148320ac52cee972f1cb5c