### PR TITLE
Use input dtype in rope_apply

### DIFF
--- a/wan/distributed/sequence_parallel.py
+++ b/wan/distributed/sequence_parallel.py
@@ -36,7 +36,7 @@ def rope_apply(x, grid_sizes, freqs):
             seq_len = f * h * w
 
             # precompute multipliers
-            x_i = torch.view_as_complex(x[i, :s].to(torch.float64).reshape(
+            x_i = torch.view_as_complex(x[i, :s].to(x.dtype).reshape(
                 s, n, -1, 2))
             freqs_i = torch.cat([
                 freqs[0][:f].view(f, 1, 1, -1).expand(f, h, w, -1),


### PR DESCRIPTION
## Summary
- use the tensor's existing dtype in `rope_apply` to avoid unnecessary float64 casts

## Testing
- `pytest -q`
- `python - <<'PY'
import os, torch, torch.distributed as dist
os.environ['MASTER_ADDR'] = 'localhost'
os.environ['MASTER_PORT'] = '12355'
dist.init_process_group('gloo', rank=0, world_size=1)
from torch import autocast

def pad_freqs(original_tensor, target_len):
    seq_len, s1, s2 = original_tensor.shape
    pad_size = target_len - seq_len
    padding_tensor = torch.ones(pad_size, s1, s2, dtype=original_tensor.dtype, device=original_tensor.device)
    padded_tensor = torch.cat([original_tensor, padding_tensor], dim=0)
    return padded_tensor

def get_rank():
    return dist.get_rank()

def get_world_size():
    return dist.get_world_size()

def rope_apply_old(x, grid_sizes, freqs):
    with autocast(device_type=x.device.type, enabled=False):
        s, n, c = x.size(1), x.size(2), x.size(3) // 2
        freqs_ = freqs.split([c - 2 * (c // 3), c // 3, c // 3], dim=1)
        output = []
        for i, (f, h, w) in enumerate(grid_sizes.tolist()):
            seq_len = f * h * w
            x_i = torch.view_as_complex(x[i, :s].to(torch.float64).reshape(s, n, -1, 2))
            freqs_i = torch.cat([
                freqs_[0][:f].view(f,1,1,-1).expand(f,h,w,-1),
                freqs_[1][:h].view(1,h,1,-1).expand(f,h,w,-1),
                freqs_[2][:w].view(1,1,w,-1).expand(f,h,w,-1)
            ], dim=-1).reshape(seq_len,1,-1)
            sp_size = get_world_size()
            sp_rank = get_rank()
            freqs_i = pad_freqs(freqs_i, s * sp_size)
            s_per_rank = s
            freqs_i_rank = freqs_i[(sp_rank*s_per_rank):((sp_rank+1)*s_per_rank),:,:]
            x_i = torch.view_as_real(x_i * freqs_i_rank).flatten(2)
            x_i = torch.cat([x_i, x[i,s:]])
            output.append(x_i)
        return torch.stack(output).float()

def rope_apply_new(x, grid_sizes, freqs):
    with autocast(device_type=x.device.type, enabled=False):
        s, n, c = x.size(1), x.size(2), x.size(3) // 2
        freqs_ = freqs.split([c - 2 * (c // 3), c // 3, c // 3], dim=1)
        output = []
        for i, (f, h, w) in enumerate(grid_sizes.tolist()):
            seq_len = f * h * w
            x_i = torch.view_as_complex(x[i, :s].to(x.dtype).reshape(s, n, -1, 2))
            freqs_i = torch.cat([
                freqs_[0][:f].view(f,1,1,-1).expand(f,h,w,-1),
                freqs_[1][:h].view(1,h,1,-1).expand(f,h,w,-1),
                freqs_[2][:w].view(1,1,w,-1).expand(f,h,w,-1)
            ], dim=-1).reshape(seq_len,1,-1)
            sp_size = get_world_size()
            sp_rank = get_rank()
            freqs_i = pad_freqs(freqs_i, s * sp_size)
            s_per_rank = s
            freqs_i_rank = freqs_i[(sp_rank*s_per_rank):((sp_rank+1)*s_per_rank),:,:]
            x_i = torch.view_as_real(x_i * freqs_i_rank).flatten(2)
            x_i = torch.cat([x_i, x[i,s:]])
            output.append(x_i)
        return torch.stack(output).float()

B,L,N,C = 1,4,1,12
x = torch.randn(B,L,N,C)
grid_sizes = torch.tensor([[1,2,2]])
freqs = torch.randn(10,C//2)
print('max abs diff:', (rope_apply_old(x.clone(), grid_sizes, freqs)-rope_apply_new(x.clone(), grid_sizes, freqs)).abs().max().item())
print('memory old bytes:', x[:,:L].to(torch.float64).nelement()*x[:,:L].to(torch.float64).element_size())
print('memory new bytes:', x[:,:L].to(x.dtype).nelement()*x[:,:L].to(x.dtype).element_size())
PY`

------
https://chatgpt.com/codex/tasks/task_e_68ac22cfc9148320b49eab7055bac387