### PR TITLE
Respect t5_cpu flag for text encoder

### DIFF
--- a/generate.py
+++ b/generate.py
@@ -258,6 +258,8 @@ def generate(args):
         device = "cpu"
     _init_logging(rank)
     logging.info(_MPS_FALLBACK_MSG)
+    if args.t5_cpu:
+        logging.info("T5 encoder will remain on CPU.")
 
     if args.offload_model is None:
         args.offload_model = False if world_size > 1 else True

--- a/wan/image2video.py
+++ b/wan/image2video.py
@@ -91,10 +91,11 @@ class WanI2V:
             self.init_on_cpu = False
 
         shard_fn = partial(shard_model, device_id=device_id)
+        t5_device = torch.device("cpu") if t5_cpu else self.device
         self.text_encoder = T5EncoderModel(
             text_len=config.text_len,
             dtype=config.t5_dtype,
-            device=self.device,
+            device=t5_device,
             checkpoint_path=os.path.join(checkpoint_dir, config.t5_checkpoint),
             tokenizer_path=os.path.join(checkpoint_dir, config.t5_tokenizer),
             shard_fn=shard_fn if t5_fsdp else None,
@@ -430,10 +431,11 @@ class WanI2V:
             if self.rank == 0:
                 videos = self.vae.decode(x0)
 
-        del noise, latent, x0
+        del context, context_null, noise, latent, x0
         del sample_scheduler
+        gc.collect()
+        empty_device_cache()
         if offload_model:
-            gc.collect()
             synchronize_device()
         if dist.is_initialized():
             dist.barrier()

--- a/wan/text2video.py
+++ b/wan/text2video.py
@@ -90,10 +90,11 @@ class WanT2V:
             self.init_on_cpu = False
 
         shard_fn = partial(shard_model, device_id=device_id)
+        t5_device = torch.device("cpu") if t5_cpu else self.device
         self.text_encoder = T5EncoderModel(
             text_len=config.text_len,
             dtype=config.t5_dtype,
-            device=self.device,
+            device=t5_device,
             checkpoint_path=os.path.join(checkpoint_dir, config.t5_checkpoint),
             tokenizer_path=os.path.join(checkpoint_dir, config.t5_tokenizer),
             shard_fn=shard_fn if t5_fsdp else None)

--- a/wan/textimage2video.py
+++ b/wan/textimage2video.py
@@ -91,10 +91,11 @@ class WanTI2V:
             self.init_on_cpu = False
 
         shard_fn = partial(shard_model, device_id=device_id)
+        t5_device = torch.device("cpu") if t5_cpu else self.device
         self.text_encoder = T5EncoderModel(
             text_len=config.text_len,
             dtype=config.t5_dtype,
-            device=self.device,
+            device=t5_device,
             checkpoint_path=os.path.join(checkpoint_dir, config.t5_checkpoint),
             tokenizer_path=os.path.join(checkpoint_dir, config.t5_tokenizer),
             shard_fn=shard_fn if t5_fsdp else None)
@@ -408,10 +409,11 @@ class WanTI2V:
             if self.rank == 0:
                 videos = self.vae.decode(x0)
 
-        del noise, latents
+        del context, context_null, noise, latents
         del sample_scheduler
+        gc.collect()
+        empty_device_cache()
         if offload_model:
-            gc.collect()
             synchronize_device()
         if dist.is_initialized():
             dist.barrier()
@@ -619,10 +621,11 @@ class WanTI2V:
             if self.rank == 0:
                 videos = self.vae.decode(x0)
 
-        del noise, latent, x0
+        del context, context_null, noise, latent, x0
         del sample_scheduler
+        gc.collect()
+        empty_device_cache()
         if offload_model:
-            gc.collect()
             synchronize_device()
         if dist.is_initialized():
             dist.barrier()


### PR DESCRIPTION
## Summary
- honor `--t5_cpu` flag by keeping T5 text encoder on CPU
- free text encoder contexts after generation to reduce GPU memory
- log when T5 encoder is kept on CPU

## Testing
- `pytest -q`
- `python -m py_compile generate.py wan/text2video.py wan/textimage2video.py wan/image2video.py`


------
https://chatgpt.com/codex/tasks/task_e_68ac22cfe41c832097314ea92f0de0b7