### PR TITLE
Clear and sync device cache after offloading

### DIFF
--- a/wan/distributed/fsdp.py
+++ b/wan/distributed/fsdp.py
@@ -8,7 +8,7 @@ from torch.distributed.fsdp import MixedPrecision, ShardingStrategy
 from torch.distributed.fsdp.wrap import lambda_auto_wrap_policy
 from torch.distributed.utils import _free_storage
 
-from ..utils.device import empty_device_cache
+from ..utils.device import empty_device_cache, synchronize_device
 
 
 def shard_model(
@@ -43,3 +43,4 @@ def free_model(model):
     del model
     gc.collect()
     empty_device_cache()
+    synchronize_device()  # ensure cached memory is reclaimed after offload

--- a/wan/image2video.py
+++ b/wan/image2video.py
@@ -206,7 +206,8 @@ class WanI2V:
                     offload_model_name).parameters()).device.type in ('cuda', 'mps'):
                 # Offload unused model from GPU/MPS to CPU to free memory
                 getattr(self, offload_model_name).to('cpu')
-                empty_device_cache()
+                empty_device_cache()  # offloaded unused model; free GPU cache
+                synchronize_device()
             if next(getattr(
                     self,
                     required_model_name).parameters()).device.type == 'cpu':
@@ -313,7 +314,8 @@ class WanI2V:
             context_null = self.text_encoder([n_prompt], self.device)
             if offload_model:
                 self.text_encoder.model.cpu()
-                empty_device_cache()
+                empty_device_cache()  # offloaded text encoder; free GPU cache
+                synchronize_device()
         else:
             context = self.text_encoder([input_prompt], torch.device('cpu'))
             context_null = self.text_encoder([n_prompt], torch.device('cpu'))
@@ -386,7 +388,8 @@ class WanI2V:
             }
 
             if offload_model:
-                empty_device_cache()
+                empty_device_cache()  # clear cache before sampling loop
+                synchronize_device()
 
             for _, t in enumerate(tqdm(timesteps)):
                 latent_model_input = [latent.to(self.device)]
@@ -403,12 +406,14 @@ class WanI2V:
                                         t=timestep,
                                         **arg_c)[0]
                 if offload_model:
-                    empty_device_cache()
+                    empty_device_cache()  # free cache after conditional pass
+                    synchronize_device()
                 noise_pred_uncond = model(latent_model_input,
                                           t=timestep,
                                           **arg_null)[0]
                 if offload_model:
-                    empty_device_cache()
+                    empty_device_cache()  # free cache after unconditional pass
+                    synchronize_device()
                 noise_pred = noise_pred_uncond + sample_guide_scale * (
                     noise_pred_cond - noise_pred_uncond)
 
@@ -425,7 +430,8 @@ class WanI2V:
             if offload_model:
                 self.low_noise_model.cpu()
                 self.high_noise_model.cpu()
-                empty_device_cache()
+                empty_device_cache()  # offload both models to CPU; clear cache
+                synchronize_device()
 
             if self.rank == 0:
                 videos = self.vae.decode(x0)
@@ -434,6 +440,7 @@ class WanI2V:
         del sample_scheduler
         if offload_model:
             gc.collect()
+            empty_device_cache()  # release cache after temporary allocations
             synchronize_device()
         if dist.is_initialized():
             dist.barrier()

--- a/wan/utils/device.py
+++ b/wan/utils/device.py
@@ -24,6 +24,9 @@ def _default_device() -> torch.device:
 def empty_device_cache(device: str | torch.device | None = None) -> None:
     """Release cached memory on the given device.
 
+    Typically invoked after offloading large models or completing
+    memory-intensive allocations to return resources to the system.
+
     Args:
         device: Optional device specification. When ``None`` the best
             available device is used.
@@ -38,6 +41,9 @@ def empty_device_cache(device: str | torch.device | None = None) -> None:
 
 def synchronize_device(device: str | torch.device | None = None) -> None:
     """Synchronize the given device if necessary.
+
+    Useful after calling :func:`empty_device_cache` or performing
+    asynchronous transfers to ensure memory is actually freed.
 
     Args:
         device: Optional device specification. When ``None`` the best


### PR DESCRIPTION
## Summary
- call `synchronize_device` after `empty_device_cache` so memory is reclaimed when offloading models or large allocations
- document cache clearing utilities and add inline comments explaining when to trigger them

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ac22cfc8108320bb742fd87ddb9543