### PR TITLE
Add dtype support to flow matching solvers

### DIFF
--- a/tests/test_dtype_schedulers.py
+++ b/tests/test_dtype_schedulers.py
@@ -1,0 +1,82 @@
+import sys
+import types
+import importlib.util
+from pathlib import Path
+
+import pytest
+import torch
+
+# Dynamically load modules from the repository without importing the whole package
+repo_root = Path(__file__).resolve().parents[1]
+wan_path = repo_root / "wan"
+
+# Create a minimal package structure for 'wan' and 'wan.utils'
+wan_module = types.ModuleType("wan")
+wan_module.__path__ = [str(wan_path)]
+sys.modules.setdefault("wan", wan_module)
+
+utils_module = types.ModuleType("wan.utils")
+utils_module.__path__ = [str(wan_path / "utils")]
+sys.modules.setdefault("wan.utils", utils_module)
+
+# Load fm_solvers
+spec = importlib.util.spec_from_file_location(
+    "wan.utils.fm_solvers", wan_path / "utils" / "fm_solvers.py"
+)
+fm_solvers = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(fm_solvers)
+
+# Load fm_solvers_unipc
+spec_unipc = importlib.util.spec_from_file_location(
+    "wan.utils.fm_solvers_unipc", wan_path / "utils" / "fm_solvers_unipc.py"
+)
+fm_solvers_unipc = importlib.util.module_from_spec(spec_unipc)
+spec_unipc.loader.exec_module(fm_solvers_unipc)
+
+FlowDPMSolverMultistepScheduler = fm_solvers.FlowDPMSolverMultistepScheduler
+get_sampling_sigmas = fm_solvers.get_sampling_sigmas
+retrieve_timesteps = fm_solvers.retrieve_timesteps
+FlowUniPCMultistepScheduler = fm_solvers_unipc.FlowUniPCMultistepScheduler
+
+
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+def test_dpm_solver_dtype(dtype):
+    sampling_steps = 5
+    scheduler_fp32 = FlowDPMSolverMultistepScheduler(num_train_timesteps=10)
+    sigmas = get_sampling_sigmas(sampling_steps, shift=1.0)
+    retrieve_timesteps(scheduler_fp32, device="cpu", sigmas=sigmas, dtype=torch.float32)
+    sigmas_fp32 = scheduler_fp32.sigmas.to(torch.float32)
+    timesteps_fp32 = scheduler_fp32.timesteps.to(torch.float32)
+
+    scheduler = FlowDPMSolverMultistepScheduler(num_train_timesteps=10)
+    retrieve_timesteps(scheduler, device="cpu", sigmas=sigmas, dtype=dtype)
+
+    assert scheduler.sigmas.dtype == dtype
+    assert scheduler.timesteps.dtype == dtype
+    assert torch.allclose(scheduler.sigmas.to(torch.float32), sigmas_fp32, atol=2e-3)
+    assert torch.allclose(
+        scheduler.timesteps.to(torch.float32), timesteps_fp32, atol=2e-2
+    )
+
+
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+def test_unipc_solver_dtype(dtype):
+    sampling_steps = 5
+    scheduler_fp32 = FlowUniPCMultistepScheduler(
+        num_train_timesteps=10, shift=1.0, use_dynamic_shifting=False
+    )
+    scheduler_fp32.set_timesteps(sampling_steps, device="cpu", shift=1.0, dtype=torch.float32)
+    sigmas_fp32 = scheduler_fp32.sigmas.to(torch.float32)
+    timesteps_fp32 = scheduler_fp32.timesteps.to(torch.float32)
+
+    scheduler = FlowUniPCMultistepScheduler(
+        num_train_timesteps=10, shift=1.0, use_dynamic_shifting=False
+    )
+    scheduler.set_timesteps(sampling_steps, device="cpu", shift=1.0, dtype=dtype)
+
+    assert scheduler.sigmas.dtype == dtype
+    assert scheduler.timesteps.dtype == dtype
+    assert torch.allclose(scheduler.sigmas.to(torch.float32), sigmas_fp32, atol=2e-3)
+    assert torch.allclose(
+        scheduler.timesteps.to(torch.float32), timesteps_fp32, atol=2e-2
+    )

--- a/wan/image2video.py
+++ b/wan/image2video.py
@@ -354,9 +354,12 @@ class WanI2V:
                     num_train_timesteps=self.num_train_timesteps,
                     shift=1,
                     use_dynamic_shifting=False)
-                sample_scheduler.set_timesteps(sampling_steps,
-                                               device=self.device,
-                                               shift=shift)
+                sample_scheduler.set_timesteps(
+                    sampling_steps,
+                    device=self.device,
+                    shift=shift,
+                    dtype=self.param_dtype,
+                )
                 timesteps = sample_scheduler.timesteps
             elif sample_solver == 'dpm++':
                 sample_scheduler = FlowDPMSolverMultistepScheduler(
@@ -364,9 +367,12 @@ class WanI2V:
                     shift=1,
                     use_dynamic_shifting=False)
                 sampling_sigmas = get_sampling_sigmas(sampling_steps, shift)
-                timesteps, _ = retrieve_timesteps(sample_scheduler,
-                                                  device=self.device,
-                                                  sigmas=sampling_sigmas)
+                timesteps, _ = retrieve_timesteps(
+                    sample_scheduler,
+                    device=self.device,
+                    sigmas=sampling_sigmas,
+                    dtype=self.param_dtype,
+                )
             else:
                 raise NotImplementedError("Unsupported solver.")
 

--- a/wan/text2video.py
+++ b/wan/text2video.py
@@ -326,9 +326,12 @@ class WanT2V:
                     num_train_timesteps=self.num_train_timesteps,
                     shift=1,
                     use_dynamic_shifting=False)
-                sample_scheduler.set_timesteps(sampling_steps,
-                                               device=self.device,
-                                               shift=shift)
+                sample_scheduler.set_timesteps(
+                    sampling_steps,
+                    device=self.device,
+                    shift=shift,
+                    dtype=self.param_dtype,
+                )
                 timesteps = sample_scheduler.timesteps
             elif sample_solver == 'dpm++':
                 sample_scheduler = FlowDPMSolverMultistepScheduler(
@@ -336,9 +339,12 @@ class WanT2V:
                     shift=1,
                     use_dynamic_shifting=False)
                 sampling_sigmas = get_sampling_sigmas(sampling_steps, shift)
-                timesteps, _ = retrieve_timesteps(sample_scheduler,
-                                                  device=self.device,
-                                                  sigmas=sampling_sigmas)
+                timesteps, _ = retrieve_timesteps(
+                    sample_scheduler,
+                    device=self.device,
+                    sigmas=sampling_sigmas,
+                    dtype=self.param_dtype,
+                )
             else:
                 raise NotImplementedError("Unsupported solver.")
 

--- a/wan/textimage2video.py
+++ b/wan/textimage2video.py
@@ -344,9 +344,12 @@ class WanTI2V:
                     num_train_timesteps=self.num_train_timesteps,
                     shift=1,
                     use_dynamic_shifting=False)
-                sample_scheduler.set_timesteps(sampling_steps,
-                                               device=self.device,
-                                               shift=shift)
+                sample_scheduler.set_timesteps(
+                    sampling_steps,
+                    device=self.device,
+                    shift=shift,
+                    dtype=self.param_dtype,
+                )
                 timesteps = sample_scheduler.timesteps
             elif sample_solver == 'dpm++':
                 sample_scheduler = FlowDPMSolverMultistepScheduler(
@@ -354,9 +357,12 @@ class WanTI2V:
                     shift=1,
                     use_dynamic_shifting=False)
                 sampling_sigmas = get_sampling_sigmas(sampling_steps, shift)
-                timesteps, _ = retrieve_timesteps(sample_scheduler,
-                                                  device=self.device,
-                                                  sigmas=sampling_sigmas)
+                timesteps, _ = retrieve_timesteps(
+                    sample_scheduler,
+                    device=self.device,
+                    sigmas=sampling_sigmas,
+                    dtype=self.param_dtype,
+                )
             else:
                 raise NotImplementedError("Unsupported solver.")
 
@@ -539,9 +545,12 @@ class WanTI2V:
                     num_train_timesteps=self.num_train_timesteps,
                     shift=1,
                     use_dynamic_shifting=False)
-                sample_scheduler.set_timesteps(sampling_steps,
-                                               device=self.device,
-                                               shift=shift)
+                sample_scheduler.set_timesteps(
+                    sampling_steps,
+                    device=self.device,
+                    shift=shift,
+                    dtype=self.param_dtype,
+                )
                 timesteps = sample_scheduler.timesteps
             elif sample_solver == 'dpm++':
                 sample_scheduler = FlowDPMSolverMultistepScheduler(
@@ -549,9 +558,12 @@ class WanTI2V:
                     shift=1,
                     use_dynamic_shifting=False)
                 sampling_sigmas = get_sampling_sigmas(sampling_steps, shift)
-                timesteps, _ = retrieve_timesteps(sample_scheduler,
-                                                  device=self.device,
-                                                  sigmas=sampling_sigmas)
+                timesteps, _ = retrieve_timesteps(
+                    sample_scheduler,
+                    device=self.device,
+                    sigmas=sampling_sigmas,
+                    dtype=self.param_dtype,
+                )
             else:
                 raise NotImplementedError("Unsupported solver.")
 


### PR DESCRIPTION
## Summary
- allow schedulers to generate sigmas/timesteps in configurable dtype (defaulting to `config.param_dtype`)
- plumb dtype through video pipelines
- add tests validating bf16/fp16 schedules against fp32

## Testing
- `pytest tests/test_dtype_schedulers.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac22cfc6a883208047541bea0a7936