### PR TITLE
Set float16 precision for Wan shared config

### DIFF
--- a/wan/configs/shared_config.py
+++ b/wan/configs/shared_config.py
@@ -7,11 +7,9 @@ wan_shared_cfg = EasyDict()
 
 # dtype
 # Users can modify this option in configuration files to switch
-# the precision of all model parameters. Half precision (float16)
-# inference is supported when FSDP is disabled.
-wan_shared_cfg.dtype = (torch.float16
-                        if torch.backends.mps.is_available()
-                        else torch.bfloat16)
+# the precision of all model parameters. Force half precision
+# (float16) for reduced memory consumption.
+wan_shared_cfg.dtype = torch.float16
 
 # t5
 wan_shared_cfg.t5_model = 'umt5_xxl'
@@ -19,7 +17,7 @@ wan_shared_cfg.t5_dtype = wan_shared_cfg.dtype
 wan_shared_cfg.text_len = 512
 
 # transformer
-wan_shared_cfg.param_dtype = wan_shared_cfg.dtype
+wan_shared_cfg.param_dtype = torch.float16
 
 # inference
 wan_shared_cfg.num_train_timesteps = 1000


### PR DESCRIPTION
## Summary
- force `wan_shared_cfg.dtype` to `torch.float16`
- use `torch.float16` for `wan_shared_cfg.param_dtype`

## Testing
- `python -m py_compile wan/configs/shared_config.py`
- `/usr/bin/time -v python generate.py --task t2v-A14B --ckpt_dir /tmp --size 1280*720 >/tmp/before.log && tail -n 20 /tmp/before.log` *(fails: required weights missing, memory ~8.3GB)*
- `/usr/bin/time -v python generate.py --task t2v-A14B --ckpt_dir /tmp --size 1280*720 >/tmp/after.log && tail -n 20 /tmp/after.log` *(fails: required weights missing, memory ~8.3GB)*

------
https://chatgpt.com/codex/tasks/task_e_68ac22cfcc0c8320846360b5c213192a