### PR TITLE
Enable optional 8/4-bit quantization for T5 encoder

### DIFF
--- a/generate.py
+++ b/generate.py
@@ -61,6 +61,8 @@ def _validate_args(args):
         assert args.image is not None, "Please specify the image path for i2v."
 
     cfg = WAN_CONFIGS[args.task]
+    if args.t5_quantization is not None:
+        cfg.t5_quantization = args.t5_quantization
 
     if args.sample_steps is None:
         args.sample_steps = cfg.sample_steps
@@ -136,6 +138,13 @@ def _parse_args():
         action="store_true",
         default=False,
         help="Whether to place T5 model on CPU.",
+    )
+    parser.add_argument(
+        "--t5_quantization",
+        type=str,
+        default=None,
+        choices=["8bit", "4bit"],
+        help="Quantization mode for T5 model.",
     )
     parser.add_argument(
         "--dit_fsdp",
@@ -307,6 +316,8 @@ def generate(args):
             )
 
     cfg = WAN_CONFIGS[args.task]
+    if args.t5_quantization is not None:
+        cfg.t5_quantization = args.t5_quantization
     if args.ulysses_size > 1:
         assert (
             cfg.num_heads % args.ulysses_size == 0

--- a/wan/configs/shared_config.py
+++ b/wan/configs/shared_config.py
@@ -16,6 +16,7 @@ wan_shared_cfg.dtype = (torch.float16
 # t5
 wan_shared_cfg.t5_model = 'umt5_xxl'
 wan_shared_cfg.t5_dtype = wan_shared_cfg.dtype
+wan_shared_cfg.t5_quantization = None
 wan_shared_cfg.text_len = 512
 
 # transformer

--- a/wan/image2video.py
+++ b/wan/image2video.py
@@ -98,8 +98,9 @@ class WanI2V:
             checkpoint_path=os.path.join(checkpoint_dir, config.t5_checkpoint),
             tokenizer_path=os.path.join(checkpoint_dir, config.t5_tokenizer),
             shard_fn=shard_fn if t5_fsdp else None,
+            quantization=config.t5_quantization,
         )
-        if not t5_fsdp:
+        if not t5_fsdp and config.t5_quantization is None:
             self.text_encoder.model.to(self.param_dtype)
 
         self.vae_stride = config.vae_stride

--- a/wan/text2video.py
+++ b/wan/text2video.py
@@ -96,8 +96,10 @@ class WanT2V:
             device=self.device,
             checkpoint_path=os.path.join(checkpoint_dir, config.t5_checkpoint),
             tokenizer_path=os.path.join(checkpoint_dir, config.t5_tokenizer),
-            shard_fn=shard_fn if t5_fsdp else None)
-        if not t5_fsdp:
+            shard_fn=shard_fn if t5_fsdp else None,
+            quantization=config.t5_quantization,
+        )
+        if not t5_fsdp and config.t5_quantization is None:
             self.text_encoder.model.to(self.param_dtype)
 
         self.vae_stride = config.vae_stride

--- a/wan/textimage2video.py
+++ b/wan/textimage2video.py
@@ -97,8 +97,10 @@ class WanTI2V:
             device=self.device,
             checkpoint_path=os.path.join(checkpoint_dir, config.t5_checkpoint),
             tokenizer_path=os.path.join(checkpoint_dir, config.t5_tokenizer),
-            shard_fn=shard_fn if t5_fsdp else None)
-        if not t5_fsdp:
+            shard_fn=shard_fn if t5_fsdp else None,
+            quantization=config.t5_quantization,
+        )
+        if not t5_fsdp and config.t5_quantization is None:
             self.text_encoder.model.to(self.param_dtype)
 
         self.vae_stride = config.vae_stride


### PR DESCRIPTION
## Summary
- add bitsandbytes-powered 8bit and 4bit loading options for T5
- expose quantization through config and CLI flag
- avoid dtype casts when quantized models are used

## Testing
- `python -m pytest`
- `bash tests/test.sh dummy 1 --mps` *(fails: ModuleNotFoundError: No module named 'PIL')*

------
https://chatgpt.com/codex/tasks/task_e_68ac22f2fe188320bf4e1291024ebf10