### PR TITLE
feat: enable bitsandbytes quantized inference

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,20 @@ export PYTORCH_ENABLE_MPS_FALLBACK=1  # optional manual override
 - Apple's GPUs have limited unified memory; if you encounter OOM errors, try running
   generation with `--offload_model True`.
 
+#### Quantized Inference (int8/nf4)
+
+Wan2.2 supports quantized weights through the [bitsandbytes](https://github.com/TimDettmers/bitsandbytes)
+library. Set `wan_shared_cfg.dtype` to `"int8"` or `"nf4"` to enable
+quantized loading. Quantized inference currently requires a single GPU and is
+incompatible with FSDP, sequence parallelism, or CPU offloading.
+
+```python
+from wan.configs.shared_config import wan_shared_cfg
+from wan.text2video import WanT2V
+
+wan_shared_cfg.dtype = "nf4"  # or "int8"
+model = WanT2V(wan_shared_cfg, "./Wan2.2-T2V-A14B", device_id=0, init_on_cpu=False)
+```
 
 #### Model Download
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ imageio-ffmpeg
 flash_attn; platform_system != "Darwin"
 xformers; platform_system == "Darwin"
 numpy>=1.23.5,<2
+bitsandbytes>=0.47.0

--- a/tests/test_quantization.py
+++ b/tests/test_quantization.py
@@ -1,0 +1,28 @@
+import importlib.util
+import pathlib
+
+import pytest
+import torch
+
+quant_module_path = pathlib.Path(__file__).resolve().parent.parent / "wan" / "utils" / "quantization.py"
+spec = importlib.util.spec_from_file_location("quantization", quant_module_path)
+quantization = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(quantization)
+quantize_model = quantization.quantize_model
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+@pytest.mark.parametrize("qtype", ["int8", "nf4"])
+def test_quantized_linear_close(qtype):
+    torch.manual_seed(0)
+    model = torch.nn.Sequential(
+        torch.nn.Linear(32, 32),
+        torch.nn.ReLU(),
+        torch.nn.Linear(32, 16),
+    ).cuda()
+    inp = torch.randn(2, 32, device="cuda", dtype=torch.float16)
+    ref = model(inp)
+    qmodel = quantize_model(model, qtype).cuda()
+    out = qmodel(inp)
+    diff = torch.mean(torch.abs(ref - out)) / torch.mean(torch.abs(ref))
+    assert diff < 0.1

--- a/wan/configs/shared_config.py
+++ b/wan/configs/shared_config.py
@@ -8,18 +8,32 @@ wan_shared_cfg = EasyDict()
 # dtype
 # Users can modify this option in configuration files to switch
 # the precision of all model parameters. Half precision (float16)
-# inference is supported when FSDP is disabled.
-wan_shared_cfg.dtype = (torch.float16
-                        if torch.backends.mps.is_available()
-                        else torch.bfloat16)
+# inference is supported when FSDP is disabled. Setting this option to
+# ``"int8"`` or ``"nf4"`` enables bitsandbytes quantization.
+if torch.backends.mps.is_available():
+    default_dtype = "float16"
+else:
+    default_dtype = "bfloat16"
+wan_shared_cfg.dtype = default_dtype
+
+_DTYPE_MAP = {
+    "float16": torch.float16,
+    "fp16": torch.float16,
+    "bfloat16": torch.bfloat16,
+    "bf16": torch.bfloat16,
+}
+
+if wan_shared_cfg.dtype in {"int8", "nf4"}:
+    # Quantized weights use float16 for computation
+    wan_shared_cfg.param_dtype = torch.float16
+else:
+    wan_shared_cfg.param_dtype = _DTYPE_MAP.get(wan_shared_cfg.dtype,
+                                                torch.bfloat16)
 
 # t5
 wan_shared_cfg.t5_model = 'umt5_xxl'
-wan_shared_cfg.t5_dtype = wan_shared_cfg.dtype
+wan_shared_cfg.t5_dtype = wan_shared_cfg.param_dtype
 wan_shared_cfg.text_len = 512
-
-# transformer
-wan_shared_cfg.param_dtype = wan_shared_cfg.dtype
 
 # inference
 wan_shared_cfg.num_train_timesteps = 1000

--- a/wan/text2video.py
+++ b/wan/text2video.py
@@ -27,6 +27,7 @@ from .utils.fm_solvers import (
     retrieve_timesteps,
 )
 from .utils.fm_solvers_unipc import FlowUniPCMultistepScheduler
+from .utils.quantization import quantize_model
 
 
 class WanT2V:
@@ -81,6 +82,12 @@ class WanT2V:
         self.rank = rank
         self.t5_cpu = t5_cpu
         self.init_on_cpu = init_on_cpu
+        self.quant_dtype = config.dtype if config.dtype in {"int8", "nf4"} else None
+
+        if self.quant_dtype and (t5_fsdp or dit_fsdp or use_sp or t5_cpu or init_on_cpu):
+            raise ValueError(
+                "Quantized inference is incompatible with FSDP, sequence parallelism, "
+                "or CPU offload.")
 
         self.num_train_timesteps = config.num_train_timesteps
         self.boundary = config.boundary
@@ -109,6 +116,9 @@ class WanT2V:
         logging.info(f"Creating WanModel from {checkpoint_dir}")
         self.low_noise_model = WanModel.from_pretrained(
             checkpoint_dir, subfolder=config.low_noise_checkpoint)
+        if self.quant_dtype:
+            self.low_noise_model = quantize_model(self.low_noise_model,
+                                                  self.quant_dtype)
         self.low_noise_model = self._configure_model(
             model=self.low_noise_model,
             use_sp=use_sp,
@@ -118,6 +128,9 @@ class WanT2V:
 
         self.high_noise_model = WanModel.from_pretrained(
             checkpoint_dir, subfolder=config.high_noise_checkpoint)
+        if self.quant_dtype:
+            self.high_noise_model = quantize_model(self.high_noise_model,
+                                                   self.quant_dtype)
         self.high_noise_model = self._configure_model(
             model=self.high_noise_model,
             use_sp=use_sp,

--- a/wan/utils/quantization.py
+++ b/wan/utils/quantization.py
@@ -1,0 +1,28 @@
+import torch
+
+
+def quantize_model(model: torch.nn.Module, quant_type: str) -> torch.nn.Module:
+    """Apply bitsandbytes quantization to all linear layers in ``model``.
+
+    Args:
+        model: The model whose ``nn.Linear`` layers will be replaced.
+        quant_type: Either ``"int8"`` or ``"nf4"``.
+
+    Returns:
+        The quantized model (modifications happen in-place).
+    """
+    import bitsandbytes as bnb
+
+    if quant_type not in {"int8", "nf4"}:
+        raise ValueError(f"Unsupported quantization type: {quant_type}")
+
+    for name, module in model.named_children():
+        if isinstance(module, torch.nn.Linear):
+            if quant_type == "int8":
+                qmodule = bnb.nn.Linear8bitLt.from_float(module)
+            else:
+                qmodule = bnb.nn.Linear4bit.from_float(module, quant_type="nf4")
+            setattr(model, name, qmodule)
+        else:
+            quantize_model(module, quant_type)
+    return model


### PR DESCRIPTION
## Summary
- allow `int8` and `nf4` dtypes in shared config and load models with bitsandbytes quantization
- document quantized inference limitations and provide sample usage
- add regression test comparing quantized outputs against full precision

## Testing
- `PYTHONPATH=. pytest tests/test_quantization.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68ac22cfcc148320860922173a410210