### PR TITLE
Offload VAE after decode to free memory

### DIFF
--- a/wan/image2video.py
+++ b/wan/image2video.py
@@ -447,6 +447,10 @@ class WanI2V:
 
             if self.rank == 0:
                 videos = self.vae.decode(x0)
+        if offload_model:
+            self.vae.model.cpu()
+            empty_device_cache()  # offload VAE to CPU; clear cache
+            synchronize_device()
 
         del noise, latent, x0
         del sample_scheduler

--- a/wan/text2video.py
+++ b/wan/text2video.py
@@ -397,6 +397,10 @@ class WanT2V:
                 synchronize_device()
             if self.rank == 0:
                 videos = self.vae.decode(x0)
+        if offload_model:
+            self.vae.model.cpu()
+            empty_device_cache()  # offload VAE to CPU; clear cache
+            synchronize_device()
 
         del context, context_null, noise, latents, arg_c, arg_null, x0
         del sample_scheduler

--- a/wan/textimage2video.py
+++ b/wan/textimage2video.py
@@ -420,6 +420,10 @@ class WanTI2V:
                 synchronize_device()
             if self.rank == 0:
                 videos = self.vae.decode(x0)
+        if offload_model:
+            self.vae.model.cpu()
+            empty_device_cache()  # offload VAE to CPU; clear cache
+            synchronize_device()
 
         del noise, latents
         del sample_scheduler
@@ -642,6 +646,10 @@ class WanTI2V:
 
             if self.rank == 0:
                 videos = self.vae.decode(x0)
+        if offload_model:
+            self.vae.model.cpu()
+            empty_device_cache()  # offload VAE to CPU; clear cache
+            synchronize_device()
 
         del noise, latent, x0
         del sample_scheduler


### PR DESCRIPTION
## Summary
- Offload VAE model to CPU after `vae.decode` in text-, image-, and text-image-to-video generation paths
- Clear device cache and synchronize to ensure memory is released

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac2515304c8320917fe7dd9e8ec326