### PR TITLE
Cast contexts to model dtype after T5 encoding

### DIFF
--- a/wan/image2video.py
+++ b/wan/image2video.py
@@ -317,7 +317,9 @@ class WanI2V:
         if not self.t5_cpu:
             self.text_encoder.model.to(self.device)
             context = self.text_encoder([input_prompt], self.device)
+            context = [t.to(self.param_dtype) for t in context]
             context_null = self.text_encoder([n_prompt], self.device)
+            context_null = [t.to(self.param_dtype) for t in context_null]
             if offload_model:
                 self.text_encoder.model.cpu()
                 empty_device_cache()  # offloaded text encoder; free GPU cache
@@ -327,6 +329,8 @@ class WanI2V:
             context_null = self.text_encoder([n_prompt], torch.device('cpu'))
             context = [t.to(self.device) for t in context]
             context_null = [t.to(self.device) for t in context_null]
+            context = [t.to(self.param_dtype) for t in context]
+            context_null = [t.to(self.param_dtype) for t in context_null]
 
         frames = torch.zeros(3,
                              F,

--- a/wan/text2video.py
+++ b/wan/text2video.py
@@ -289,7 +289,9 @@ class WanT2V:
         if not self.t5_cpu:
             self.text_encoder.model.to(self.device)
             context = self.text_encoder([input_prompt], self.device)
+            context = [t.to(self.param_dtype) for t in context]
             context_null = self.text_encoder([n_prompt], self.device)
+            context_null = [t.to(self.param_dtype) for t in context_null]
             if offload_model:
                 self.text_encoder.model.cpu()
                 empty_device_cache()  # offloaded text encoder; free GPU cache
@@ -299,6 +301,8 @@ class WanT2V:
             context_null = self.text_encoder([n_prompt], torch.device('cpu'))
             context = [t.to(self.device) for t in context]
             context_null = [t.to(self.device) for t in context_null]
+            context = [t.to(self.param_dtype) for t in context]
+            context_null = [t.to(self.param_dtype) for t in context_null]
 
         noise = [
             torch.randn(target_shape[0],

--- a/wan/textimage2video.py
+++ b/wan/textimage2video.py
@@ -311,7 +311,9 @@ class WanTI2V:
         if not self.t5_cpu:
             self.text_encoder.model.to(self.device)
             context = self.text_encoder([input_prompt], self.device)
+            context = [t.to(self.param_dtype) for t in context]
             context_null = self.text_encoder([n_prompt], self.device)
+            context_null = [t.to(self.param_dtype) for t in context_null]
             if offload_model:
                 self.text_encoder.model.cpu()
                 empty_device_cache()  # offloaded text encoder; free GPU cache
@@ -321,6 +323,8 @@ class WanTI2V:
             context_null = self.text_encoder([n_prompt], torch.device('cpu'))
             context = [t.to(self.device) for t in context]
             context_null = [t.to(self.device) for t in context_null]
+            context = [t.to(self.param_dtype) for t in context]
+            context_null = [t.to(self.param_dtype) for t in context_null]
 
         noise = [
             torch.randn(target_shape[0],
@@ -523,7 +527,9 @@ class WanTI2V:
         if not self.t5_cpu:
             self.text_encoder.model.to(self.device)
             context = self.text_encoder([input_prompt], self.device)
+            context = [t.to(self.param_dtype) for t in context]
             context_null = self.text_encoder([n_prompt], self.device)
+            context_null = [t.to(self.param_dtype) for t in context_null]
             if offload_model:
                 self.text_encoder.model.cpu()
                 empty_device_cache()  # offloaded text encoder; free GPU cache
@@ -533,6 +539,8 @@ class WanTI2V:
             context_null = self.text_encoder([n_prompt], torch.device('cpu'))
             context = [t.to(self.device) for t in context]
             context_null = [t.to(self.device) for t in context_null]
+            context = [t.to(self.param_dtype) for t in context]
+            context_null = [t.to(self.param_dtype) for t in context_null]
 
         z = self.vae.encode([img])
 


### PR DESCRIPTION
## Summary
- Ensure text encoder outputs are cast to `param_dtype` immediately after generation
- Apply dtype casting for both GPU and CPU (`t5_cpu`) execution paths
- Update text-to-video, image-to-video, and text-image-to-video pipelines

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac25179e0c832085b76aba21504ccb