### PR TITLE
Compute noise guidance difference in-place

### DIFF
--- a/wan/text2video.py
+++ b/wan/text2video.py
@@ -372,15 +372,14 @@ class WanT2V:
                 sample_guide_scale = guide_scale[1] if t.item(
                 ) >= boundary else guide_scale[0]
 
-                noise_pred_cond = model(latent_model_input,
-                                        t=timestep,
-                                        **arg_c)[0]
-                noise_pred_uncond = model(latent_model_input,
-                                          t=timestep,
-                                          **arg_null)[0]
-
-                noise_pred = noise_pred_uncond + sample_guide_scale * (
-                    noise_pred_cond - noise_pred_uncond)
+                noise_pred = model(
+                    latent_model_input, t=timestep, **arg_c)[0]
+                noise_pred -= model(latent_model_input,
+                                     t=timestep,
+                                     **arg_null)[0]
+                noise_pred = model(latent_model_input,
+                                   t=timestep,
+                                   **arg_null)[0] + sample_guide_scale * noise_pred
 
                 temp_x0 = sample_scheduler.step(noise_pred.unsqueeze(0),
                                                 t,


### PR DESCRIPTION
## Summary
- Compute conditional and unconditional noise difference directly in text2video loop
- Remove `noise_pred_uncond` tensor to reduce memory footprint

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac24dad4d883209de4ad31006b5933