### PR TITLE
Use centralized device selection

### DIFF
--- a/wan/image2video.py
+++ b/wan/image2video.py
@@ -29,6 +29,7 @@ from .utils.fm_solvers import (
 )
 from .utils.fm_solvers_unipc import FlowUniPCMultistepScheduler
 from .utils.device import empty_device_cache, synchronize_device
+from .utils.utils import get_best_device
 
 
 class WanI2V:
@@ -72,12 +73,7 @@ class WanI2V:
                 Convert DiT model parameters dtype to 'config.param_dtype'.
                 Only works without FSDP.
         """
-        if torch.cuda.is_available():
-            self.device = torch.device(f"cuda:{device_id}")
-        elif torch.backends.mps.is_available():
-            self.device = torch.device("mps")
-        else:
-            self.device = torch.device("cpu")
+        self.device = get_best_device()
         self.config = config
         self.rank = rank
         self.t5_cpu = t5_cpu

--- a/wan/text2video.py
+++ b/wan/text2video.py
@@ -27,6 +27,7 @@ from .utils.fm_solvers import (
     retrieve_timesteps,
 )
 from .utils.fm_solvers_unipc import FlowUniPCMultistepScheduler
+from .utils.utils import get_best_device
 
 
 class WanT2V:
@@ -71,12 +72,7 @@ class WanT2V:
                 Convert DiT model parameters dtype to 'config.param_dtype'.
                 Only works without FSDP.
         """
-        if torch.cuda.is_available():
-            self.device = torch.device(f"cuda:{device_id}")
-        elif torch.backends.mps.is_available():
-            self.device = torch.device("mps")
-        else:
-            self.device = torch.device("cpu")
+        self.device = get_best_device()
         self.config = config
         self.rank = rank
         self.t5_cpu = t5_cpu

--- a/wan/textimage2video.py
+++ b/wan/textimage2video.py
@@ -29,7 +29,7 @@ from .utils.fm_solvers import (
     retrieve_timesteps,
 )
 from .utils.fm_solvers_unipc import FlowUniPCMultistepScheduler
-from .utils.utils import best_output_size, masks_like
+from .utils.utils import best_output_size, masks_like, get_best_device
 
 
 class WanTI2V:
@@ -73,12 +73,7 @@ class WanTI2V:
                 Convert DiT model parameters dtype to 'config.param_dtype'.
                 Only works without FSDP.
         """
-        if torch.cuda.is_available():
-            self.device = torch.device(f"cuda:{device_id}")
-        elif torch.backends.mps.is_available():
-            self.device = torch.device("mps")
-        else:
-            self.device = torch.device("cpu")
+        self.device = get_best_device()
         self.config = config
         self.rank = rank
         self.t5_cpu = t5_cpu


### PR DESCRIPTION
## Summary
- use get_best_device for unified device selection in text2video, image2video, and textimage2video modules

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac2ade3e388320a83262f98ac01f66