### PR TITLE
Ensure float32 tensors on MPS

### DIFF
--- a/wan/modules/attention.py
+++ b/wan/modules/attention.py
@@ -26,6 +26,7 @@ except ModuleNotFoundError:
     XFORMERS_AVAILABLE = False
 
 import warnings
+from ..utils import ensure_float32
 
 __all__ = [
     "flash_attention",
@@ -163,6 +164,9 @@ def attention(
     dtype=torch.bfloat16,
     fa_version=None,
 ):
+    q = ensure_float32(q)
+    k = ensure_float32(k)
+    v = ensure_float32(v)
     if (FLASH_ATTN_2_AVAILABLE or FLASH_ATTN_3_AVAILABLE) and q.device.type == "cuda":
         return flash_attention(
             q=q,

--- a/wan/modules/vae2_2.py
+++ b/wan/modules/vae2_2.py
@@ -8,6 +8,7 @@ from einops import rearrange
 from torch import autocast
 
 from ..utils.utils import get_best_device
+from ..utils import ensure_float32
 
 __all__ = [
     "Wan2_2_VAE",
@@ -34,9 +35,10 @@ class CausalConv3d(nn.Conv3d):
         self.padding = (0, 0, 0)
 
     def forward(self, x, cache_x=None):
+        x = ensure_float32(x)
         padding = list(self._padding)
         if cache_x is not None and self._padding[4] > 0:
-            cache_x = cache_x.to(x.device)
+            cache_x = ensure_float32(cache_x).to(x.device)
             x = torch.cat([cache_x, x], dim=2)
             padding[4] -= cache_x.shape[2]
         x = F.pad(x, padding)
@@ -57,6 +59,7 @@ class RMS_norm(nn.Module):
         self.bias = nn.Parameter(torch.zeros(shape)) if bias else 0.0
 
     def forward(self, x):
+        x = ensure_float32(x)
         return (F.normalize(x, dim=(1 if self.channel_first else -1)) *
                 self.scale * self.gamma + self.bias)
 
@@ -67,6 +70,7 @@ class Upsample(nn.Upsample):
         """
         Fix bfloat16 support for nearest neighbor interpolation.
         """
+        x = ensure_float32(x)
         return super().forward(x.float()).type_as(x)
 
 
@@ -115,6 +119,7 @@ class Resample(nn.Module):
             self.resample = nn.Identity()
 
     def forward(self, x, feat_cache=None, feat_idx=[0]):
+        x = ensure_float32(x)
         b, c, t, h, w = x.size()
         if self.mode == "upsample3d":
             if feat_cache is not None:
@@ -340,6 +345,7 @@ class AvgDown3D(nn.Module):
         self.group_size = in_channels * self.factor // out_channels
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x = ensure_float32(x)
         pad_t = (self.factor_t - x.shape[2] % self.factor_t) % self.factor_t
         pad = (0, 0, 0, 0, pad_t, 0)
         x = F.pad(x, pad)
@@ -395,6 +401,7 @@ class DupUp3D(nn.Module):
         self.repeats = out_channels * self.factor // in_channels
 
     def forward(self, x: torch.Tensor, first_chunk=False) -> torch.Tensor:
+        x = ensure_float32(x)
         x = x.repeat_interleave(self.repeats, dim=1)
         x = x.view(
             x.size(0),


### PR DESCRIPTION
## Summary
- Cast query, key, and value tensors to float32 on MPS in attention
- Apply MPS float32 casting in model preprocessing and VAE utility layers

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'torch')*


------
https://chatgpt.com/codex/tasks/task_e_68ac2ae7c79883208cde2fa577e1839a