### PR TITLE
Free device cache before synchronizing

### DIFF
--- a/generate.py
+++ b/generate.py
@@ -17,7 +17,7 @@ from PIL import Image
 import wan
 from wan.configs import MAX_AREA_CONFIGS, SIZE_CONFIGS, SUPPORTED_SIZES, WAN_CONFIGS
 from wan.distributed.util import init_distributed_group
-from wan.utils.device import synchronize_device
+from wan.utils.device import empty_device_cache, synchronize_device
 from wan.utils.prompt_extend import DashScopePromptExpander, QwenPromptExpander
 from wan.utils.utils import save_video, str2bool
 
@@ -466,7 +466,7 @@ def generate(args):
             value_range=(-1, 1),
         )
     del video
-
+    empty_device_cache()
     synchronize_device()
     if dist.is_initialized():
         dist.barrier()


### PR DESCRIPTION
## Summary
- import `empty_device_cache`
- release device cache after video generation before syncing

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ac2af2907c832091c7e2012d94ba51