### PR TITLE
feat: configurable precision for generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,20 @@ yourself before running the script:
 export PYTORCH_ENABLE_MPS_FALLBACK=1  # optional manual override
 ```
 
+##### Precision
+
+`generate.py` selects a default precision based on the detected device (fp16 on CUDA,
+fp32 on Apple's MPS backend). You can override this with the `--precision`
+argument:
+
+- `fp16`: lowest memory use and typically fastest.
+- `bf16`: similar memory to fp16 with a wider numeric range; requires hardware support.
+- `fp32`: highest memory use but most compatible. Required for some MPS operations;
+  the script automatically falls back to fp32 on MPS when needed.
+
+Choosing a lower precision reduces GPU memory consumption but may not be supported
+on all hardware.
+
 **Troubleshooting**
 
 - Ensure macOS 12.3 or later and the Xcode command-line tools are installed.
@@ -165,7 +179,7 @@ To facilitate implementation, we will start with a basic version of the inferenc
 - Single-GPU inference
 
 ``` sh
-python generate.py  --task t2v-A14B --size 1280*720 --ckpt_dir ./Wan2.2-T2V-A14B --offload_model True --convert_model_dtype --prompt "Two anthropomorphic cats in comfy boxing gear and bright gloves fight intensely on a spotlighted stage."
+python generate.py  --task t2v-A14B --size 1280*720 --ckpt_dir ./Wan2.2-T2V-A14B --offload_model True --convert_model_dtype --precision fp16 --prompt "Two anthropomorphic cats in comfy boxing gear and bright gloves fight intensely on a spotlighted stage."
 ```
 
 > 💡 This command can run on a GPU with at least 80GB VRAM.
@@ -216,7 +230,7 @@ This repository supports the `Wan2.2-I2V-A14B` Image-to-Video model and can simu
 
 - Single-GPU inference
 ```sh
-python generate.py --task i2v-A14B --size 1280*720 --ckpt_dir ./Wan2.2-I2V-A14B --offload_model True --convert_model_dtype --image examples/i2v_input.JPG --prompt "Summer beach vacation style, a white cat wearing sunglasses sits on a surfboard. The fluffy-furred feline gazes directly at the camera with a relaxed expression. Blurred beach scenery forms the background featuring crystal-clear waters, distant green hills, and a blue sky dotted with white clouds. The cat assumes a naturally relaxed posture, as if savoring the sea breeze and warm sunlight. A close-up shot highlights the feline's intricate details and the refreshing atmosphere of the seaside."
+python generate.py --task i2v-A14B --size 1280*720 --ckpt_dir ./Wan2.2-I2V-A14B --offload_model True --convert_model_dtype --precision fp16 --image examples/i2v_input.JPG --prompt "Summer beach vacation style, a white cat wearing sunglasses sits on a surfboard. The fluffy-furred feline gazes directly at the camera with a relaxed expression. Blurred beach scenery forms the background featuring crystal-clear waters, distant green hills, and a blue sky dotted with white clouds. The cat assumes a naturally relaxed posture, as if savoring the sea breeze and warm sunlight. A close-up shot highlights the feline's intricate details and the refreshing atmosphere of the seaside."
 ```
 
 > This command can run on a GPU with at least 80GB VRAM.
@@ -247,7 +261,7 @@ This repository supports the `Wan2.2-TI2V-5B` Text-Image-to-Video model and can 
 
 - Single-GPU Text-to-Video inference
 ```sh
-python generate.py --task ti2v-5B --size 1280*704 --ckpt_dir ./Wan2.2-TI2V-5B --offload_model True --convert_model_dtype --t5_cpu --prompt "Two anthropomorphic cats in comfy boxing gear and bright gloves fight intensely on a spotlighted stage"
+python generate.py --task ti2v-5B --size 1280*704 --ckpt_dir ./Wan2.2-TI2V-5B --offload_model True --convert_model_dtype --precision fp16 --t5_cpu --prompt "Two anthropomorphic cats in comfy boxing gear and bright gloves fight intensely on a spotlighted stage"
 ```
 
 > 💡Unlike other tasks, the 720P resolution of the Text-Image-to-Video task is `1280*704` or `704*1280`.
@@ -259,7 +273,7 @@ python generate.py --task ti2v-5B --size 1280*704 --ckpt_dir ./Wan2.2-TI2V-5B --
 
 - Single-GPU Image-to-Video inference
 ```sh
-python generate.py --task ti2v-5B --size 1280*704 --ckpt_dir ./Wan2.2-TI2V-5B --offload_model True --convert_model_dtype --t5_cpu --image examples/i2v_input.JPG --prompt "Summer beach vacation style, a white cat wearing sunglasses sits on a surfboard. The fluffy-furred feline gazes directly at the camera with a relaxed expression. Blurred beach scenery forms the background featuring crystal-clear waters, distant green hills, and a blue sky dotted with white clouds. The cat assumes a naturally relaxed posture, as if savoring the sea breeze and warm sunlight. A close-up shot highlights the feline's intricate details and the refreshing atmosphere of the seaside."
+python generate.py --task ti2v-5B --size 1280*704 --ckpt_dir ./Wan2.2-TI2V-5B --offload_model True --convert_model_dtype --precision fp16 --t5_cpu --image examples/i2v_input.JPG --prompt "Summer beach vacation style, a white cat wearing sunglasses sits on a surfboard. The fluffy-furred feline gazes directly at the camera with a relaxed expression. Blurred beach scenery forms the background featuring crystal-clear waters, distant green hills, and a blue sky dotted with white clouds. The cat assumes a naturally relaxed posture, as if savoring the sea breeze and warm sunlight. A close-up shot highlights the feline's intricate details and the refreshing atmosphere of the seaside."
 ```
 
 > 💡If the image parameter is configured, it is an Image-to-Video generation; otherwise, it defaults to a Text-to-Video generation.

--- a/generate.py
+++ b/generate.py
@@ -16,6 +16,7 @@ from PIL import Image
 
 import wan
 from wan.configs import MAX_AREA_CONFIGS, SIZE_CONFIGS, SUPPORTED_SIZES, WAN_CONFIGS
+from wan.configs.shared_config import set_precision, wan_shared_cfg
 from wan.distributed.util import init_distributed_group
 from wan.utils.device import synchronize_device
 from wan.utils.prompt_extend import DashScopePromptExpander, QwenPromptExpander
@@ -231,6 +232,13 @@ def _parse_args():
         ),
     )
     parser.add_argument(
+        "--precision",
+        type=str,
+        default=None,
+        choices=["fp32", "fp16", "bf16"],
+        help="Precision for model parameters and computation. Defaults to a device-dependent choice.",
+    )
+    parser.add_argument(
         "--dist_backend",
         type=str,
         default=None,
@@ -319,6 +327,9 @@ def generate(args):
             )
 
     cfg = WAN_CONFIGS[args.task]
+    cfg.dtype = wan_shared_cfg.dtype
+    cfg.param_dtype = wan_shared_cfg.param_dtype
+    cfg.t5_dtype = wan_shared_cfg.t5_dtype
     if args.t5_quantization is not None:
         cfg.t5_quantization = args.t5_quantization
     if args.ulysses_size > 1:
@@ -477,4 +488,5 @@ def generate(args):
 
 if __name__ == "__main__":
     args = _parse_args()
+    set_precision(args.precision)
     generate(args)

--- a/wan/configs/shared_config.py
+++ b/wan/configs/shared_config.py
@@ -5,23 +5,53 @@ from easydict import EasyDict
 #------------------------ Wan shared config ------------------------#
 wan_shared_cfg = EasyDict()
 
-# dtype
-# Users can modify this option in configuration files to switch
-# the precision of all model parameters. Force half precision
-# (float16) for reduced memory consumption.
-wan_shared_cfg.dtype = torch.float16
+# precision utilities
+_PRECISION_MAP = {
+    "fp32": torch.float32,
+    "fp16": torch.float16,
+    "bf16": torch.bfloat16,
+}
+
+def _default_dtype():
+    """Detect a reasonable default dtype based on the runtime device."""
+    return torch.float32 if torch.backends.mps.is_available() else torch.float16
+
+def set_precision(precision: str | None):
+    """Set the global precision for Wan models.
+
+    Parameters
+    ----------
+    precision: str or None
+        Desired precision string ("fp32", "fp16" or "bf16"). If ``None``, a
+        device specific default will be used. When running on Apple's MPS
+        backend, unsupported half-precision modes will fall back to ``fp32``.
+    """
+    if precision is None:
+        dtype = _default_dtype()
+    else:
+        dtype = _PRECISION_MAP.get(precision.lower(), _default_dtype())
+    if torch.backends.mps.is_available() and dtype != torch.float32:
+        # Some MPS operations require float32; ensure compatibility.
+        dtype = torch.float32
+    wan_shared_cfg.dtype = dtype
+    wan_shared_cfg.t5_dtype = dtype
+    wan_shared_cfg.param_dtype = dtype
+    return dtype
+
+# Initialize with the default precision.
+set_precision(None)
 
 # t5
 wan_shared_cfg.t5_model = 'umt5_xxl'
-wan_shared_cfg.t5_dtype = wan_shared_cfg.dtype
 wan_shared_cfg.t5_quantization = None
 wan_shared_cfg.text_len = 512
-
-# transformer
-wan_shared_cfg.param_dtype = torch.float16
 
 # inference
 wan_shared_cfg.num_train_timesteps = 1000
 wan_shared_cfg.sample_fps = 16
-wan_shared_cfg.sample_neg_prompt = '色调艳丽，过曝，静态，细节模糊不清，字幕，风格，作品，画作，画面，静止，整体发灰，最差质量，低质量，JPEG压缩残留，丑陋的，残缺的，多余的手指，画得不好的手部，画得不好的脸部，畸形的，毁容的，形态畸形的肢体，手指融合，静止不动的画面，杂乱的背景，三条腿，背景人很多，倒着走'
+wan_shared_cfg.sample_neg_prompt = (
+    '色调艳丽，过曝，静态，细节模糊不清，字幕，风格，作品，画作，画面，静止，整体发灰，最差质量，'
+    '低质量，JPEG压缩残留，丑陋的，残缺的，多余的手指，画得不好的手部，画得不好的脸部，畸形的，'
+    '毁容的，形态畸形的肢体，手指融合，静止不动的画面，杂乱的背景，三条腿，背景人很多，倒着走'
+)
 wan_shared_cfg.frame_num = 81


### PR DESCRIPTION
## Summary
- add `--precision` flag to select fp32, fp16 or bf16 when running `generate.py`
- wire precision through shared config and model configs with MPS-aware fallback
- document precision trade-offs and example usage

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac2af6a59c83208c61f07229e9127f