### PR TITLE
Centralize device selection across modules

### DIFF
--- a/generate.py
+++ b/generate.py
@@ -17,7 +17,7 @@ from PIL import Image
 import wan
 from wan.configs import MAX_AREA_CONFIGS, SIZE_CONFIGS, SUPPORTED_SIZES, WAN_CONFIGS
 from wan.distributed.util import init_distributed_group
-from wan.utils.device import synchronize_device
+from wan.utils.device import get_best_device, synchronize_device
 from wan.utils.prompt_extend import DashScopePromptExpander, QwenPromptExpander
 from wan.utils.utils import save_video, str2bool
 
@@ -262,12 +262,7 @@ def generate(args):
     rank = int(os.getenv("RANK", 0))
     world_size = int(os.getenv("WORLD_SIZE", 1))
     local_rank = int(os.getenv("LOCAL_RANK", 0))
-    if torch.cuda.is_available():
-        device = local_rank
-    elif torch.backends.mps.is_available():
-        device = "mps"
-    else:
-        device = "cpu"
+    device = get_best_device(local_rank)
     _init_logging(rank)
     logging.info(_MPS_FALLBACK_MSG)
 
@@ -277,11 +272,11 @@ def generate(args):
     backend = (
         args.dist_backend
         or os.getenv("WAN_BACKEND")
-        or ("nccl" if torch.cuda.is_available() else "gloo")
+        or ("nccl" if device.type == "cuda" else "gloo")
     )
     if world_size > 1:
-        if torch.cuda.is_available():
-            torch.cuda.set_device(local_rank)
+        if device.type == "cuda":
+            torch.cuda.set_device(device)
         dist.init_process_group(
             backend=backend, init_method="env://", rank=rank, world_size=world_size
         )
@@ -311,7 +306,7 @@ def generate(args):
                 model_name=args.prompt_extend_model,
                 task=args.task,
                 is_vl=args.image is not None,
-                device=rank,
+                device=device,
             )
         else:
             raise NotImplementedError(
@@ -369,7 +364,7 @@ def generate(args):
         wan_t2v = wan.WanT2V(
             config=cfg,
             checkpoint_dir=args.ckpt_dir,
-            device_id=device,
+            device=device,
             rank=rank,
             t5_fsdp=args.t5_fsdp,
             dit_fsdp=args.dit_fsdp,
@@ -395,7 +390,7 @@ def generate(args):
         wan_ti2v = wan.WanTI2V(
             config=cfg,
             checkpoint_dir=args.ckpt_dir,
-            device_id=device,
+            device=device,
             rank=rank,
             t5_fsdp=args.t5_fsdp,
             dit_fsdp=args.dit_fsdp,
@@ -423,7 +418,7 @@ def generate(args):
         wan_i2v = wan.WanI2V(
             config=cfg,
             checkpoint_dir=args.ckpt_dir,
-            device_id=device,
+            device=device,
             rank=rank,
             t5_fsdp=args.t5_fsdp,
             dit_fsdp=args.dit_fsdp,

--- a/wan/distributed/util.py
+++ b/wan/distributed/util.py
@@ -3,6 +3,8 @@ import os
 import torch
 import torch.distributed as dist
 
+from ..utils.device import get_best_device
+
 
 def init_distributed_group(backend: str | None = None):
     """Initialize sequence parallel group.
@@ -12,10 +14,9 @@ def init_distributed_group(backend: str | None = None):
     available, otherwise ``'gloo'``.
     """
     if backend is None:
-        backend = (
-            os.getenv("WAN_BACKEND")
-            or ("nccl" if torch.cuda.is_available() else "gloo")
-        )
+        backend = os.getenv("WAN_BACKEND")
+        if backend is None:
+            backend = "nccl" if get_best_device().type == "cuda" else "gloo"
     if not dist.is_initialized():
         dist.init_process_group(backend=backend)
 

--- a/wan/image2video.py
+++ b/wan/image2video.py
@@ -28,7 +28,7 @@ from .utils.fm_solvers import (
     retrieve_timesteps,
 )
 from .utils.fm_solvers_unipc import FlowUniPCMultistepScheduler
-from .utils.device import empty_device_cache, synchronize_device
+from .utils.device import empty_device_cache, get_best_device, synchronize_device
 
 
 class WanI2V:
@@ -37,7 +37,7 @@ class WanI2V:
         self,
         config,
         checkpoint_dir,
-        device_id=0,
+        device: torch.device | None = None,
         rank=0,
         t5_fsdp=False,
         dit_fsdp=False,
@@ -54,8 +54,8 @@ class WanI2V:
                 Object containing model parameters initialized from config.py
             checkpoint_dir (`str`):
                 Path to directory containing model checkpoints
-            device_id (`int`,  *optional*, defaults to 0):
-                Id of target GPU device
+            device (``torch.device``, *optional*, defaults to ``None``):
+                Target device. When ``None`` the best available device is used.
             rank (`int`,  *optional*, defaults to 0):
                 Process rank for distributed training
             t5_fsdp (`bool`, *optional*, defaults to False):
@@ -72,12 +72,7 @@ class WanI2V:
                 Convert DiT model parameters dtype to 'config.param_dtype'.
                 Only works without FSDP.
         """
-        if torch.cuda.is_available():
-            self.device = torch.device(f"cuda:{device_id}")
-        elif torch.backends.mps.is_available():
-            self.device = torch.device("mps")
-        else:
-            self.device = torch.device("cpu")
+        self.device = device or get_best_device()
         self.config = config
         self.rank = rank
         self.t5_cpu = t5_cpu
@@ -90,7 +85,7 @@ class WanI2V:
         if t5_fsdp or dit_fsdp or use_sp:
             self.init_on_cpu = False
 
-        shard_fn = partial(shard_model, device_id=device_id)
+        shard_fn = partial(shard_model, device_id=self.device)
         self.text_encoder = T5EncoderModel(
             text_len=config.text_len,
             dtype=config.t5_dtype,

--- a/wan/modules/t5.py
+++ b/wan/modules/t5.py
@@ -7,6 +7,7 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
+from ..utils.device import get_best_device
 from .tokenizers import HuggingfaceTokenizer
 
 __all__ = [
@@ -521,12 +522,8 @@ class T5EncoderModel:
         quantization=None,
     ):
         if device is None:
-            if torch.cuda.is_available():
-                device = torch.device(f"cuda:{torch.cuda.current_device()}")
-            elif torch.backends.mps.is_available():
-                device = torch.device("mps")
-            else:
-                device = torch.device("cpu")
+            device = get_best_device(torch.cuda.current_device()
+                                     if torch.cuda.is_available() else None)
         self.text_len = text_len
         self.dtype = dtype
         self.device = device

--- a/wan/textimage2video.py
+++ b/wan/textimage2video.py
@@ -22,7 +22,7 @@ from .distributed.util import get_world_size
 from .modules.model import WanModel
 from .modules.t5 import T5EncoderModel
 from .modules.vae2_2 import Wan2_2_VAE
-from .utils.device import empty_device_cache, synchronize_device
+from .utils.device import empty_device_cache, get_best_device, synchronize_device
 from .utils.fm_solvers import (
     FlowDPMSolverMultistepScheduler,
     get_sampling_sigmas,
@@ -38,7 +38,7 @@ class WanTI2V:
         self,
         config,
         checkpoint_dir,
-        device_id=0,
+        device: torch.device | None = None,
         rank=0,
         t5_fsdp=False,
         dit_fsdp=False,
@@ -55,8 +55,8 @@ class WanTI2V:
                 Object containing model parameters initialized from config.py
             checkpoint_dir (`str`):
                 Path to directory containing model checkpoints
-            device_id (`int`,  *optional*, defaults to 0):
-                Id of target GPU device
+            device (``torch.device``, *optional*, defaults to ``None``):
+                Target device. When ``None`` the best available device is used.
             rank (`int`,  *optional*, defaults to 0):
                 Process rank for distributed training
             t5_fsdp (`bool`, *optional*, defaults to False):
@@ -73,12 +73,7 @@ class WanTI2V:
                 Convert DiT model parameters dtype to 'config.param_dtype'.
                 Only works without FSDP.
         """
-        if torch.cuda.is_available():
-            self.device = torch.device(f"cuda:{device_id}")
-        elif torch.backends.mps.is_available():
-            self.device = torch.device("mps")
-        else:
-            self.device = torch.device("cpu")
+        self.device = device or get_best_device()
         self.config = config
         self.rank = rank
         self.t5_cpu = t5_cpu
@@ -90,7 +85,7 @@ class WanTI2V:
         if t5_fsdp or dit_fsdp or use_sp:
             self.init_on_cpu = False
 
-        shard_fn = partial(shard_model, device_id=device_id)
+        shard_fn = partial(shard_model, device_id=self.device)
         self.text_encoder = T5EncoderModel(
             text_len=config.text_len,
             dtype=config.t5_dtype,

--- a/wan/utils/utils.py
+++ b/wan/utils/utils.py
@@ -10,19 +10,9 @@ import imageio
 import torch
 import torchvision
 
+from .device import get_best_device
+
 __all__ = ['save_video', 'save_image', 'str2bool', 'get_best_device']
-
-
-def get_best_device():
-    """Return the best available torch device.
-
-    Preference order is CUDA, then MPS (Apple Silicon), and finally CPU.
-    """
-    if torch.cuda.is_available():
-        return torch.device("cuda")
-    if torch.backends.mps.is_available():
-        return torch.device("mps")
-    return torch.device("cpu")
 
 
 def rand_name(length=8, suffix=''):


### PR DESCRIPTION
## Summary
- expose `get_best_device` utility to choose CUDA/MPS/CPU
- replace inline device checks in generation pipelines with the shared helper
- default to returning `torch.device` objects to simplify downstream usage

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*


------
https://chatgpt.com/codex/tasks/task_e_68ac2af8eb108320b36b7dcadc19cf49