### PR TITLE
feat: add MPS watermark override

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -56,6 +56,13 @@ the script:
 export PYTORCH_ENABLE_MPS_FALLBACK=1  # optional manual override
 ```
 
+`generate.py` also defaults `TORCH_MPS_HIGH_WATERMARK_RATIO` to `0.8` to balance
+MPS memory usage. Lower ratios free memory back to macOS more aggressively,
+reducing OOM risk at the cost of performance, while higher ratios keep more
+memory cached for speed but may exhaust available resources. Override the
+default with `--mps-watermark <ratio>` or by setting the environment variable
+manually.
+
 ---
 
 ### Running the Model

--- a/README.md
+++ b/README.md
@@ -119,6 +119,12 @@ yourself before running the script:
 export PYTORCH_ENABLE_MPS_FALLBACK=1  # optional manual override
 ```
 
+`generate.py` also defaults `TORCH_MPS_HIGH_WATERMARK_RATIO=0.8` to limit how
+much memory the MPS backend caches. Lower ratios return memory to macOS more
+aggressively (safer on smaller GPUs but slower), while higher ratios keep more
+memory reserved for potential speedups at the risk of OOM. Override this value
+with `--mps-watermark <ratio>` or by setting the environment variable yourself.
+
 **Troubleshooting**
 
 - Ensure macOS 12.3 or later and the Xcode command-line tools are installed.


### PR DESCRIPTION
## Summary
- set a default TORCH_MPS_HIGH_WATERMARK_RATIO when MPS is detected
- add `--mps-watermark` CLI option to override the ratio
- document MPS watermark trade-offs in macOS setup guides

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ac2b02dfc48320b3c0d70625e115fd