### PR TITLE
Default T5 to CPU on macOS

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -56,6 +56,10 @@ the script:
 export PYTORCH_ENABLE_MPS_FALLBACK=1  # optional manual override
 ```
 
+By default, `generate.py` also places the T5 model on the CPU when MPS is
+available, equivalent to passing the `--t5_cpu` flag. Use `--no_t5_cpu` to keep
+the model on the GPU.
+
 ---
 
 ### Running the Model

--- a/generate.py
+++ b/generate.py
@@ -79,6 +79,13 @@ def _validate_args(args):
     args.base_seed = (
         args.base_seed if args.base_seed >= 0 else random.randint(0, sys.maxsize)
     )
+
+    # Ensure the T5 model remains on CPU by default on macOS unless explicitly
+    # overridden via ``--t5_cpu`` or ``--no_t5_cpu``.
+    if torch.backends.mps.is_available() and not any(
+        flag in sys.argv for flag in ("--t5_cpu", "--no_t5_cpu")
+    ):
+        args.t5_cpu = True
     # Size check
     assert (
         args.size in SUPPORTED_SIZES[args.task]
@@ -133,11 +140,21 @@ def _parse_args():
         default=False,
         help="Whether to use FSDP for T5.",
     )
+    # On macOS (MPS available), default to running T5 on the CPU to reduce GPU memory
+    # pressure. Users can disable this behavior with ``--no_t5_cpu``.
+    t5_cpu_default = torch.backends.mps.is_available()
     parser.add_argument(
         "--t5_cpu",
+        dest="t5_cpu",
         action="store_true",
-        default=False,
+        default=t5_cpu_default,
         help="Whether to place T5 model on CPU.",
+    )
+    parser.add_argument(
+        "--no_t5_cpu",
+        dest="t5_cpu",
+        action="store_false",
+        help="Do not place T5 model on CPU.",
     )
     parser.add_argument(
         "--t5_quantization",


### PR DESCRIPTION
## Summary
- Detect macOS/MPS and default `--t5_cpu` to on, with `--no_t5_cpu` override
- Preserve default T5 CPU setting during argument validation
- Document macOS default in INSTALL instructions

## Testing
- `python generate.py --help | head -n 40`
- `bash tests/test.sh /tmp 1 --mps` *(fails: process killed, missing model checkpoints)*

------
https://chatgpt.com/codex/tasks/task_e_68ac2b07849c8320858e448ac768394a